### PR TITLE
Soil sensors: 16 channels, hide admittance, fix HA display precision

### DIFF
--- a/src/EcoWitt.Controller.Tests/DiscoveryBuilderTest.cs
+++ b/src/EcoWitt.Controller.Tests/DiscoveryBuilderTest.cs
@@ -112,6 +112,26 @@ public class DiscoveryBuilderTest
     }
 
     [Test]
+    public void BuildSensorConfig_WithDisplayPrecision_SetsField()
+    {
+        var device = DiscoveryBuilder.BuildDevice("gw1");
+        var origin = DiscoveryBuilder.BuildOrigin();
+        var config = DiscoveryBuilder.BuildSensorConfig(device, origin, "Soil Battery 1", "ec_gw1_soilbatt1_voltage", "voltage", "ecowitt/gw1/diag/soil-battery-1", unitOfMeasurement: "V", displayPrecision: 2);
+
+        Assert.That(config.SuggestedDisplayPrecision, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void BuildSensorConfig_WithoutDisplayPrecision_FieldIsNull()
+    {
+        var device = DiscoveryBuilder.BuildDevice("gw1");
+        var origin = DiscoveryBuilder.BuildOrigin();
+        var config = DiscoveryBuilder.BuildSensorConfig(device, origin, "Indoor Temperature", "ec_gw1_tempinf_temperature", "temperature", "ecowitt/gw1/sensors/indoor-temperature", unitOfMeasurement: "°C");
+
+        Assert.That(config.SuggestedDisplayPrecision, Is.Null);
+    }
+
+    [Test]
     public void BuildSwitchConfig()
     {
         var device = DiscoveryBuilder.BuildDevice("valve1");

--- a/src/EcoWitt.Controller.Tests/SensorBuilderTest.cs
+++ b/src/EcoWitt.Controller.Tests/SensorBuilderTest.cs
@@ -189,7 +189,8 @@ public class SensorBuilderTest
         var sensor = SensorBuilder.BuildSensor("soilad2", "123");
         Assert.That(sensor, Is.Not.Null);
         Assert.That(sensor!.Alias, Is.EqualTo("Soil Admittance 2"));
-        Assert.That(sensor.UnitOfMeasurement, Is.EqualTo("mS"));
+        Assert.That(sensor.UnitOfMeasurement, Is.Empty);
+        Assert.That(sensor.SensorCategory, Is.EqualTo(SensorCategory.Diagnostic));
     }
 
     [Test]
@@ -207,6 +208,7 @@ public class SensorBuilderTest
         var sensor = SensorBuilder.BuildSensor("soilad16", "180");
         Assert.That(sensor, Is.Not.Null);
         Assert.That(sensor!.Alias, Is.EqualTo("Soil Admittance 16"));
+        Assert.That(sensor.SensorCategory, Is.EqualTo(SensorCategory.Diagnostic));
     }
 
     [Test]

--- a/src/EcoWitt.Controller.Tests/SensorBuilderTest.cs
+++ b/src/EcoWitt.Controller.Tests/SensorBuilderTest.cs
@@ -193,6 +193,32 @@ public class SensorBuilderTest
     }
 
     [Test]
+    public void BuildSensor_SoilMoisture_Channel16()
+    {
+        var sensor = SensorBuilder.BuildSensor("soilmoisture16", "42.0");
+        Assert.That(sensor, Is.Not.Null);
+        Assert.That(sensor!.Alias, Is.EqualTo("Soil Moisture 16"));
+        Assert.That(sensor.SensorType, Is.EqualTo(SensorType.Moisture));
+    }
+
+    [Test]
+    public void BuildSensor_SoilAdmittance_Channel16()
+    {
+        var sensor = SensorBuilder.BuildSensor("soilad16", "180");
+        Assert.That(sensor, Is.Not.Null);
+        Assert.That(sensor!.Alias, Is.EqualTo("Soil Admittance 16"));
+    }
+
+    [Test]
+    public void BuildSensor_SoilBattery_Channel16()
+    {
+        var sensor = SensorBuilder.BuildSensor("soilbatt16", "1.5");
+        Assert.That(sensor, Is.Not.Null);
+        Assert.That(sensor!.Alias, Is.EqualTo("Soil Battery 16"));
+        Assert.That(sensor.SensorType, Is.EqualTo(SensorType.Voltage));
+    }
+
+    [Test]
     public void BuildSensor_PM25Channel()
     {
         var sensor = SensorBuilder.BuildSensor("pm25_ch1", "12.5", isMetric: true);

--- a/src/Ecowitt.Controller/Model/Api/GatewayApiData.cs
+++ b/src/Ecowitt.Controller/Model/Api/GatewayApiData.cs
@@ -14,9 +14,8 @@ public class GatewayApiData
     //PASSKEY, stationtype, runtime, dateutc, tempinf, humidityin, baromrelin, baromabsin, tf_co2, humi_co2, pm25_co2, pm25_24h_co2, pm10_co2, pm10_24h_co2, co2, co2_24h, co2_batt, freq, model
     
     // Request form keys: PASSKEY, stationtype, runtime, heap, dateutc, tempinf, humidityin, baromrelin, baromabsin, tempf, humidity, winddir, windspeedmph, windgustmph, maxdailygust, solarradiation,
-    // uv, rrain_piezo, erain_piezo, hrain_piezo, drain_piezo, wrain_piezo, mrain_piezo, yrain_piezo, ws90cap_volt, ws90_ver, soilmoisture1, soilad1, soilmoisture2, soilad2, soilmoisture3, soilad3, soilmoisture4,
-    // soilad4, soilmoisture5, soilad5, soilmoisture6, soilad6, soilmoisture7, soilad7, soilmoisture8, soilad8, lightning_num, lightning, lightning_time, soilbatt1, soilbatt2, soilbatt3, soilbatt4, soilbatt5, soilbatt6,
-    // soilbatt7, soilbatt8, wh57batt, wh90batt, freq, model, interval
+    // uv, rrain_piezo, erain_piezo, hrain_piezo, drain_piezo, wrain_piezo, mrain_piezo, yrain_piezo, ws90cap_volt, ws90_ver, soilmoisture1..16, soilad1..16, soilbatt1..16,
+    // lightning_num, lightning, lightning_time, wh57batt, wh90batt, freq, model, interval
 
     public string Payload { get; set; } = string.Empty;
 }

--- a/src/Ecowitt.Controller/Model/Discovery/Config.cs
+++ b/src/Ecowitt.Controller/Model/Discovery/Config.cs
@@ -36,8 +36,10 @@ public class Config
     public AvailabilityMode? AvailabilityMode { get; set; }
     [JsonPropertyName("value_template")]
     public string? ValueTemplate { get; set; }
-    [JsonPropertyName("entity_category")] 
+    [JsonPropertyName("entity_category")]
     public string? SensorCategory { get; set; }
+    [JsonPropertyName("suggested_display_precision")]
+    public int? SuggestedDisplayPrecision { get; set; }
 
     [JsonPropertyName("payload_on")]
     public string? PayloadOn { get; set; }

--- a/src/Ecowitt.Controller/Model/Discovery/DiscoveryBuilder.cs
+++ b/src/Ecowitt.Controller/Model/Discovery/DiscoveryBuilder.cs
@@ -165,7 +165,7 @@ public static class DiscoveryBuilder
     /// <param name="retain"></param>
     /// <param name="qos"></param>
     /// <returns></returns>
-    public static Config BuildSensorConfig(Device device, Origin origin, string name, string uniqueId, string sensor_category, string stateTopic, string valueTemplate = "{{ value_json.value }}", string? unitOfMeasurement = "", string? icon = "", string? sensorCategory = "", bool isBinarySensor = false, bool? retain = false, int? qos = 1)
+    public static Config BuildSensorConfig(Device device, Origin origin, string name, string uniqueId, string sensor_category, string stateTopic, string valueTemplate = "{{ value_json.value }}", string? unitOfMeasurement = "", string? icon = "", string? sensorCategory = "", bool isBinarySensor = false, int? displayPrecision = null, bool? retain = false, int? qos = 1)
     {
         var result = new Config
         {
@@ -184,7 +184,8 @@ public static class DiscoveryBuilder
         if (!string.IsNullOrWhiteSpace(unitOfMeasurement)) result.UnitOfMeasurement = unitOfMeasurement;
         if (!string.IsNullOrWhiteSpace(icon)) result.Icon = icon;
         if (!string.IsNullOrWhiteSpace(sensorCategory)) result.SensorCategory = sensorCategory;
-        
+        if (displayPrecision.HasValue) result.SuggestedDisplayPrecision = displayPrecision;
+
         return result;
     }
 

--- a/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.Builder.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.Builder.cs
@@ -233,8 +233,8 @@ namespace Ecowitt.Controller.Model.Mapping
 
         private static int GetNumber(string propertyName)
         {
-            const string pattern = @"^[a-zA-Z_0-9]*(\d+)$";
-            var m = Regex.Match(propertyName, pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            const string pattern = @"(\d+)$";
+            var m = Regex.Match(propertyName, pattern, RegexOptions.Compiled);
             return m.Success ? int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture) : -1;
         }
 

--- a/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.cs
@@ -113,8 +113,9 @@ namespace Ecowitt.Controller.Model.Mapping
                 case "soilad14":
                 case "soilad15":
                 case "soilad16":
+                    // soilad is a unitless raw probe ADC reading used to derive soilmoisture, not user-facing data.
                     number = GetNumber(propertyName);
-                    return BuildIntSensor(propertyName, $"Soil Admittance {number}", propertyValue, "mS");
+                    return BuildIntSensor(propertyName, $"Soil Admittance {number}", propertyValue, isDiag: true);
                 case "pm25_ch1":
                 case "pm25_ch2":
                 case "pm25_ch3":

--- a/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.cs
@@ -87,6 +87,14 @@ namespace Ecowitt.Controller.Model.Mapping
                 case "soilmoisture6":
                 case "soilmoisture7":
                 case "soilmoisture8":
+                case "soilmoisture9":
+                case "soilmoisture10":
+                case "soilmoisture11":
+                case "soilmoisture12":
+                case "soilmoisture13":
+                case "soilmoisture14":
+                case "soilmoisture15":
+                case "soilmoisture16":
                     number = GetNumber(propertyName);
                     return BuildDoubleSensor(propertyName, $"Soil Moisture {number}", propertyValue, "%", SensorType.Moisture);
                 case "soilad1":
@@ -97,6 +105,14 @@ namespace Ecowitt.Controller.Model.Mapping
                 case "soilad6":
                 case "soilad7":
                 case "soilad8":
+                case "soilad9":
+                case "soilad10":
+                case "soilad11":
+                case "soilad12":
+                case "soilad13":
+                case "soilad14":
+                case "soilad15":
+                case "soilad16":
                     number = GetNumber(propertyName);
                     return BuildIntSensor(propertyName, $"Soil Admittance {number}", propertyValue, "mS");
                 case "pm25_ch1":
@@ -193,6 +209,14 @@ namespace Ecowitt.Controller.Model.Mapping
                 case "soilbatt6":
                 case "soilbatt7":
                 case "soilbatt8":
+                case "soilbatt9":
+                case "soilbatt10":
+                case "soilbatt11":
+                case "soilbatt12":
+                case "soilbatt13":
+                case "soilbatt14":
+                case "soilbatt15":
+                case "soilbatt16":
                     number = GetNumber(propertyName);
                     return BuildVoltageSensor(propertyName, $"Soil Battery {number}", propertyValue, true);
                 case "pm25batt1":

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.DiscoveryPublisher.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.DiscoveryPublisher.cs
@@ -77,9 +77,13 @@ namespace Ecowitt.Controller.Service.Mqtt
                 : "{{ value_json.value }}";
             //var valueTemplate = "{{ value_json.value }}";
 
+            // HA voltage/temperature/etc default to integer display unless told otherwise; mirror the
+            // publish-side rounding precision so e.g. soilbatt 1.4V isn't rendered as "1 V".
+            int? displayPrecision = sensor.DataType == SensorDataType.Double ? (_mqttConfig?.Precision ?? 2) : null;
+
             var config = sensor.SensorCategory == SensorCategory.Diagnostic
-                ? DiscoveryBuilder.BuildSensorConfig(device, _origin, sensor.Alias, id, category, statetopic, valueTemplate: valueTemplate, unitOfMeasurement: sensor.UnitOfMeasurement, sensorCategory: sensor.SensorCategory.ToString().ToLower(), isBinarySensor: sensor.SensorClass == SensorClass.BinarySensor)
-                : DiscoveryBuilder.BuildSensorConfig(device, _origin, sensor.Alias, id, category, statetopic, valueTemplate: valueTemplate, unitOfMeasurement: sensor.UnitOfMeasurement, isBinarySensor: sensor.SensorClass == SensorClass.BinarySensor);
+                ? DiscoveryBuilder.BuildSensorConfig(device, _origin, sensor.Alias, id, category, statetopic, valueTemplate: valueTemplate, unitOfMeasurement: sensor.UnitOfMeasurement, sensorCategory: sensor.SensorCategory.ToString().ToLower(), isBinarySensor: sensor.SensorClass == SensorClass.BinarySensor, displayPrecision: displayPrecision)
+                : DiscoveryBuilder.BuildSensorConfig(device, _origin, sensor.Alias, id, category, statetopic, valueTemplate: valueTemplate, unitOfMeasurement: sensor.UnitOfMeasurement, isBinarySensor: sensor.SensorClass == SensorClass.BinarySensor, displayPrecision: displayPrecision);
 
             var sensorClassTopic = BuildSensorClassTopic(sensor.SensorClass);
 


### PR DESCRIPTION
## Summary
- **Extend WH51 soil sensors 8 → 16 channels** (`soilmoisture`, `soilad`, `soilbatt`). Recent Ecowitt firmware allows 16 connected probes; channels 9-16 were previously dropped at the default branch of `SensorBuilder.BuildSensor` and only logged as ignored.
- **Mark soil admittance diagnostic and drop the bogus `mS` unit.** `soilad` is the raw probe ADC reading the gateway uses to derive `soilmoisture`, not user-facing data. HA tucks it under the device's diagnostic section instead of the default card. Closes #6.
- **Add `suggested_display_precision` to the HA discovery payload** for `SensorDataType.Double` sensors. Fixes the symptom where `soilbatt` 1.4 V was rendered as `2 V` in HA despite the MQTT state payload correctly carrying the decimal — HA's voltage device class defaults to integer display unless told otherwise. Precision mirrors `MqttConfig.Precision` (default 2). Integer sensors get null so the field is omitted via `JsonIgnoreCondition.WhenWritingNull`.
- **Fix latent regex bug in `GetNumber()`.** `^[a-zA-Z_0-9]*(\d+)$` greedily ate the leading digit on 2-digit channels — channel 16 would have shown as "Soil Moisture 6" even after extending the switch. Replaced with `(\d+)$` which captures the full trailing run. Verified `pm25_ch1`-style multi-digit names still resolve correctly.