### PR TITLE
refactor: route subdevice commands through the message bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # custom stuff
 src/Ecowitt.Controller/appsettings.Development.json
+ROADMAP.md
 
 # AI
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # custom stuff
 src/Ecowitt.Controller/appsettings.Development.json
 ROADMAP.md
+docs/plans/
 
 # AI
 CLAUDE.md

--- a/src/Ecowitt.Controller/Model/Message/Data/SubdeviceCommandDispatch.cs
+++ b/src/Ecowitt.Controller/Model/Message/Data/SubdeviceCommandDispatch.cs
@@ -1,0 +1,10 @@
+using Ecowitt.Controller.Model.Api;
+
+namespace Ecowitt.Controller.Model.Message.Data;
+
+public class SubdeviceCommandDispatch
+{
+    public string GatewayIp { get; set; } = string.Empty;
+    public SubdeviceApiCommand Command { get; set; } = new();
+    public SubdeviceModel Model { get; set; } = SubdeviceModel.Unknown;
+}

--- a/src/Ecowitt.Controller/Program.cs
+++ b/src/Ecowitt.Controller/Program.cs
@@ -104,6 +104,8 @@ public class Program
             // statemachine -> HttpPublishingService
             smb.Produce<HttpConfig>(x => x.DefaultTopic("config-http"));
             smb.Consume<HttpConfig>(x => x.Topic("config-http").WithConsumer<HttpPublishingService>());
+            smb.Produce<SubdeviceCommandDispatch>(x => x.DefaultTopic("subdevice-command-dispatch"));
+            smb.Consume<SubdeviceCommandDispatch>(x => x.Topic("subdevice-command-dispatch").WithConsumer<HttpPublishingService>());
 
             // HttpPublishingService -> statemachine
             smb.Produce<SubdeviceApiAggregate>(x => x.DefaultTopic("subdevice-api-data"));

--- a/src/Ecowitt.Controller/Service/Http/HttpPublishingService.Consumer.cs
+++ b/src/Ecowitt.Controller/Service/Http/HttpPublishingService.Consumer.cs
@@ -14,6 +14,6 @@ namespace Ecowitt.Controller.Service.Http
         }
 
         public Task OnHandle(SubdeviceCommandDispatch message, CancellationToken cancellationToken)
-            => SendSubdeviceCommand(message.GatewayIp, message.Command, message.Model);
+            => SendSubdeviceCommand(message.GatewayIp, message.Command, message.Model, cancellationToken);
     }
 }

--- a/src/Ecowitt.Controller/Service/Http/HttpPublishingService.Consumer.cs
+++ b/src/Ecowitt.Controller/Service/Http/HttpPublishingService.Consumer.cs
@@ -1,4 +1,5 @@
 ﻿using Ecowitt.Controller.Model.Message.Config;
+using Ecowitt.Controller.Model.Message.Data;
 
 namespace Ecowitt.Controller.Service.Http
 {
@@ -11,5 +12,8 @@ namespace Ecowitt.Controller.Service.Http
 
             return Task.CompletedTask;
         }
+
+        public Task OnHandle(SubdeviceCommandDispatch message, CancellationToken cancellationToken)
+            => SendSubdeviceCommand(message.GatewayIp, message.Command, message.Model);
     }
 }

--- a/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
+++ b/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
@@ -115,7 +115,7 @@ public partial class HttpPublishingService : BackgroundService, IHostedLifecycle
         return string.Empty;
     }
 
-    public async Task<bool> SendSubdeviceCommand(string gatewayIp, SubdeviceApiCommand command, SubdeviceModel model)
+    private async Task<bool> SendSubdeviceCommand(string gatewayIp, SubdeviceApiCommand command, SubdeviceModel model)
     {
         var host = _config.Hosts.FirstOrDefault(h => h.Host == gatewayIp);
         if (host == null)

--- a/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
+++ b/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
@@ -1,12 +1,13 @@
 using Ecowitt.Controller.Model;
 using Ecowitt.Controller.Model.Api;
 using Ecowitt.Controller.Model.Message.Config;
+using Ecowitt.Controller.Model.Message.Data;
 using SlimMessageBus;
 using System.Text.Json;
 
 namespace Ecowitt.Controller.Service.Http;
 
-public partial class HttpPublishingService : BackgroundService, IHostedLifecycleService, IConsumer<HttpConfig>
+public partial class HttpPublishingService : BackgroundService, IHostedLifecycleService, IConsumer<HttpConfig>, IConsumer<SubdeviceCommandDispatch>
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger _logger;

--- a/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
+++ b/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
@@ -115,7 +115,7 @@ public partial class HttpPublishingService : BackgroundService, IHostedLifecycle
         return string.Empty;
     }
 
-    private async Task<bool> SendSubdeviceCommand(string gatewayIp, SubdeviceApiCommand command, SubdeviceModel model)
+    private async Task<bool> SendSubdeviceCommand(string gatewayIp, SubdeviceApiCommand command, SubdeviceModel model, CancellationToken cancellationToken)
     {
         var host = _config.Hosts.FirstOrDefault(h => h.Host == gatewayIp);
         if (host == null)
@@ -158,7 +158,7 @@ public partial class HttpPublishingService : BackgroundService, IHostedLifecycle
             var json = JsonSerializer.Serialize(payload);
             _logger.LogDebug("Sending command payload: {Json}", json);
             var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("parse_quick_cmd_iot", content);
+            var response = await client.PostAsync("parse_quick_cmd_iot", content, cancellationToken);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
@@ -41,7 +41,12 @@ namespace Ecowitt.Controller.Service.Orchestrator
                 message.AlwaysOn = true;
             }
 
-            await _httpPublishingService.SendSubdeviceCommand(gw.IpAddress, message, subdevice.Model);
+            await _messageBus.Publish(new SubdeviceCommandDispatch
+            {
+                GatewayIp = gw.IpAddress,
+                Command = message,
+                Model = subdevice.Model
+            });
         }
 
         public async Task OnHandle(GatewayApiData message, CancellationToken cancellationToken)

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.cs
@@ -5,7 +5,6 @@ using Ecowitt.Controller.Model.Configuration;
 using Ecowitt.Controller.Model.Message.Config;
 using Ecowitt.Controller.Model.Message.Data;
 using Ecowitt.Controller.Model.Message.Event;
-using Ecowitt.Controller.Service.Http;
 using Microsoft.Extensions.Options;
 using SlimMessageBus;
 
@@ -19,9 +18,8 @@ public partial class Dispatcher : BackgroundService, IConsumer<MqttServiceEvent>
     private readonly ControllerOptions _controllerOptions;
     private readonly MqttOptions _mqttOptions;
     private readonly IMessageBus _messageBus;
-    private readonly HttpPublishingService _httpPublishingService;
 
-    public Dispatcher(ILogger<Dispatcher> logger, IDeviceStore deviceStore, IMessageBus messageBus, IOptions<MqttOptions> mqttOptions, IOptions<EcowittOptions> ecowittOptions, IOptions<ControllerOptions> controllerOptions, HttpPublishingService httpPublishingService)
+    public Dispatcher(ILogger<Dispatcher> logger, IDeviceStore deviceStore, IMessageBus messageBus, IOptions<MqttOptions> mqttOptions, IOptions<EcowittOptions> ecowittOptions, IOptions<ControllerOptions> controllerOptions)
     {
         _logger = logger;
         _deviceStore = deviceStore;
@@ -29,7 +27,6 @@ public partial class Dispatcher : BackgroundService, IConsumer<MqttServiceEvent>
         _ecowittOptions = ecowittOptions.Value;
         _controllerOptions = controllerOptions.Value;
         _messageBus = messageBus;
-        _httpPublishingService = httpPublishingService;
     }
     
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)


### PR DESCRIPTION
## Summary
- Adds `SubdeviceCommandDispatch` bus message carrying gateway IP, the original `SubdeviceApiCommand`, and the subdevice model.
- `Dispatcher` publishes this message instead of invoking `HttpPublishingService.SendSubdeviceCommand` directly. Drops the `HttpPublishingService` DI dependency from `Dispatcher` entirely.
- `HttpPublishingService` consumes the new message and delegates to the (now-private) `SendSubdeviceCommand`. All gateway HTTP traffic in the process now flows through one class.
- No externally observable behavior change.

## Why
This was the only direct service-to-service call in the codebase — every other cross-service interaction goes through the bus. The asymmetry made threading and concurrency hard to reason about. With this in, the next two roadmap items (per-gateway concurrency semaphore, then `get_livedata_info` polling) become safe to implement on top of a single, well-bounded HTTP class.