### PR TITLE
fix: HA device_class compatibility warnings (livedata rain rate, subdevice RSSI)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -111,7 +111,7 @@ Retrieves all current sensor readings from the gateway.
 }
 ```
 
-**Value format and unit passthrough:** Values come either as `"<number> <unit>"` (e.g. `"21.60 km/h"`, `"22.3 mm"`, `"8 km"`) or as a bare number with the unit in a sibling field (e.g. `wh25.unit = "C"`). The unit suffix reflects whatever the user has configured in WSView for that quantity — Ecowitt's API respects the gateway display setting. The controller parses both forms and passes the unit string straight through to HA's `unit_of_measurement`; no source-side conversion is performed. Two minor normalizations: bare `"C"`/`"F"` get the degree symbol prefixed (HA's `device_class: temperature` requires `°C`/`°F`/`K`), and solar `"W/m2"` is rewritten as `"W/m²"` for cross-mode visual consistency.
+**Value format and unit passthrough:** Values come either as `"<number> <unit>"` (e.g. `"21.60 km/h"`, `"22.3 mm"`, `"8 km"`) or as a bare number with the unit in a sibling field (e.g. `wh25.unit = "C"`). The unit suffix reflects whatever the user has configured in WSView for that quantity — Ecowitt's API respects the gateway display setting. The controller parses both forms and passes the unit string straight through to HA's `unit_of_measurement`; no source-side conversion is performed. A small `CanonicalizeUnit` map handles the gateway unit strings that HA's `device_class` validation rejects: `"C"`/`"F"` → `"°C"`/`"°F"` (temperature), `"W/m2"` → `"W/m²"` (irradiance), and `"mm/Hr"`/`"in/Hr"` → `"mm/h"`/`"in/h"` (precipitation_intensity). Everything else passes through verbatim.
 
 **Sensor ID mapping** (`common_list`):
 

--- a/src/EcoWitt.Controller.Tests/LiveDataExtensionTest.cs
+++ b/src/EcoWitt.Controller.Tests/LiveDataExtensionTest.cs
@@ -371,4 +371,47 @@ public class LiveDataExtensionTest
         Assert.That((double)rain!.Value!, Is.EqualTo(0.87).Within(0.001));
         Assert.That(rain.UnitOfMeasurement, Is.EqualTo("in"));
     }
+
+    [Test]
+    public void Map_PiezoRain_RainRateUnit_CanonicalizedToMmPerH()
+    {
+        // Gateway sends rain rate as "1.2 mm/Hr"; HA's precipitation_intensity device class
+        // rejects "mm/Hr" and requires "mm/h". Canonicalize on the way out.
+        var data = new GatewayLiveData
+        {
+            IpAddress = "192.168.0.1",
+            TimestampUtc = DateTime.UtcNow,
+            PiezoRain = new List<PiezoRainItem>
+            {
+                new() { Id = "0x0E", Val = "1.2 mm/Hr" }
+            }
+        };
+
+        var device = data.Map(isMetric: true, calculateValues: false);
+
+        var rate = device.Sensors.FirstOrDefault(s => s.Name == "rrain_piezo");
+        Assert.That(rate, Is.Not.Null);
+        Assert.That((double)rate!.Value!, Is.EqualTo(1.2).Within(0.01));
+        Assert.That(rate.UnitOfMeasurement, Is.EqualTo("mm/h"));
+    }
+
+    [Test]
+    public void Map_PiezoRain_RainRateUnit_ImperialCanonicalizedToInPerH()
+    {
+        var data = new GatewayLiveData
+        {
+            IpAddress = "192.168.0.1",
+            TimestampUtc = DateTime.UtcNow,
+            PiezoRain = new List<PiezoRainItem>
+            {
+                new() { Id = "0x0E", Val = "0.05 in/Hr" }
+            }
+        };
+
+        var device = data.Map(isMetric: false, calculateValues: false);
+
+        var rate = device.Sensors.FirstOrDefault(s => s.Name == "rrain_piezo");
+        Assert.That(rate, Is.Not.Null);
+        Assert.That(rate!.UnitOfMeasurement, Is.EqualTo("in/h"));
+    }
 }

--- a/src/EcoWitt.Controller.Tests/SensorBuilderTest.cs
+++ b/src/EcoWitt.Controller.Tests/SensorBuilderTest.cs
@@ -384,4 +384,16 @@ public class SensorBuilderTest
         Assert.That(sensor, Is.Not.Null);
         Assert.That(sensor!.SensorCategory, Is.EqualTo(SensorCategory.Diagnostic));
     }
+
+    [Test]
+    public void BuildSensor_Wfc02Rssi_NoSignalStrengthDeviceClass()
+    {
+        // wfc02rssi is a 0-4 quality level, not dBm — must NOT use the signal_strength device class
+        // (HA requires dBm/dB and warns on a unitless signal_strength entity). gw_rssi (dBm) keeps it.
+        var sensor = SensorBuilder.BuildSensor("wfc02rssi", "4");
+        Assert.That(sensor, Is.Not.Null);
+        Assert.That(sensor!.SensorType, Is.EqualTo(SensorType.None));
+        Assert.That(sensor.UnitOfMeasurement, Is.EqualTo(string.Empty));
+        Assert.That(sensor.SensorCategory, Is.EqualTo(SensorCategory.Diagnostic));
+    }
 }

--- a/src/Ecowitt.Controller/Model/Mapping/LiveDataExtension.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/LiveDataExtension.cs
@@ -37,7 +37,7 @@ public static class LiveDataExtension
     {
         foreach (var r in readings)
         {
-            var tempUnit = NormalizeTemperatureUnit(r.Unit);
+            var tempUnit = CanonicalizeUnit(r.Unit);
             var temp = SensorBuilder.BuildDoubleSensor("tempinf", "Indoor Temperature", r.Intemp, tempUnit, SensorType.Temperature);
             if (temp != null) sensors.Add(temp);
 
@@ -82,7 +82,7 @@ public static class LiveDataExtension
         {
             if (!int.TryParse(r.Channel, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ch)) continue;
 
-            var tempUnit = NormalizeTemperatureUnit(r.Unit);
+            var tempUnit = CanonicalizeUnit(r.Unit);
             var temp = SensorBuilder.BuildDoubleSensor($"temp{ch}f", $"Channel {ch} Temperature", r.Temp, tempUnit, SensorType.Temperature);
             if (temp != null) sensors.Add(temp);
 
@@ -114,7 +114,7 @@ public static class LiveDataExtension
     {
         foreach (var r in readings)
         {
-            var tempUnit = NormalizeTemperatureUnit(r.Unit);
+            var tempUnit = CanonicalizeUnit(r.Unit);
             var temp = SensorBuilder.BuildDoubleSensor("tf_co2", "CO2 Temperature", r.Temp, tempUnit, SensorType.Temperature);
             if (temp != null) sensors.Add(temp);
 
@@ -153,7 +153,7 @@ public static class LiveDataExtension
 
             var (val, unit) = SplitValueAndUnit(r.Val);
             var type = propertyName == "rrain_piezo" ? SensorType.PrecipitationIntensity : SensorType.Precipitation;
-            var sensor = SensorBuilder.BuildDoubleSensor(propertyName, RainAliasFor(propertyName), val, unit, type);
+            var sensor = SensorBuilder.BuildDoubleSensor(propertyName, RainAliasFor(propertyName), val, CanonicalizeUnit(unit), type);
             if (sensor != null) sensors.Add(sensor);
         }
 
@@ -218,9 +218,9 @@ public static class LiveDataExtension
     {
         return propertyName switch
         {
-            "tempf"          => SensorBuilder.BuildDoubleSensor("tempf",          "Outdoor Temperature",    rawValue, NormalizeTemperatureUnit(unit), SensorType.Temperature),
-            "dewpoint"       => SensorBuilder.BuildDoubleSensor("dewpoint",       "Dew Point",              rawValue, NormalizeTemperatureUnit(unit), SensorType.Temperature),
-            "feelslike"      => SensorBuilder.BuildDoubleSensor("feelslike",      "Feels Like",             rawValue, NormalizeTemperatureUnit(unit), SensorType.Temperature),
+            "tempf"          => SensorBuilder.BuildDoubleSensor("tempf",          "Outdoor Temperature",    rawValue, CanonicalizeUnit(unit), SensorType.Temperature),
+            "dewpoint"       => SensorBuilder.BuildDoubleSensor("dewpoint",       "Dew Point",              rawValue, CanonicalizeUnit(unit), SensorType.Temperature),
+            "feelslike"      => SensorBuilder.BuildDoubleSensor("feelslike",      "Feels Like",             rawValue, CanonicalizeUnit(unit), SensorType.Temperature),
             "humidity"       => SensorBuilder.BuildDoubleSensor("humidity",       "Outdoor Humidity",       rawValue, "%", SensorType.Humidity),
             "winddir"        => SensorBuilder.BuildIntSensor   ("winddir",        "Wind Direction",         rawValue, "°"),
             "windspeedmph"   => SensorBuilder.BuildDoubleSensor("windspeedmph",   "Wind Speed",             rawValue, unit, SensorType.WindSpeed),
@@ -261,12 +261,16 @@ public static class LiveDataExtension
 
     private static string StripUnit(string raw) => SplitValueAndUnit(raw).Value;
 
-    // HA's device_class:temperature requires "°C"/"°F"/"K". The Ecowitt gateway sends bare "C" or "F"
-    // in the separate `unit` field. Prepend the degree symbol; passthrough anything else.
-    private static string NormalizeTemperatureUnit(string unit) => unit switch
+    // Maps Ecowitt gateway unit strings to HA-canonical units where they differ, so HA device_class
+    // validation accepts them. Single source of truth for the known mismatches; everything else passes
+    // through verbatim (unit-passthrough remains the default).
+    private static string CanonicalizeUnit(string unit) => unit switch
     {
-        "C" => "°C",
+        "C" => "°C",        // device_class:temperature requires °C/°F/K (gateway sends bare C/F)
         "F" => "°F",
+        "W/m2" => "W/m²",   // device_class:irradiance / display consistency
+        "mm/Hr" => "mm/h",  // device_class:precipitation_intensity rejects mm/Hr
+        "in/Hr" => "in/h",
         _ => unit
     };
 

--- a/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/SensorBuilder.cs
@@ -311,7 +311,8 @@ namespace Ecowitt.Controller.Model.Mapping
                 case "wfc02_status":
                     return BuildIntSensor(propertyName, "WFC02 Status", propertyValue, isDiag: true);
                 case "wfc02rssi":
-                    return BuildIntSensor(propertyName, "WFC02 RSSI", propertyValue, type: SensorType.SignalStrength, isDiag: true);
+                    // 0-4 signal-quality level, not dBm — no signal_strength device_class (HA requires dBm/dB).
+                    return BuildIntSensor(propertyName, "WFC02 RSSI", propertyValue, isDiag: true);
                 case "wfc02batt":
                     return BuildBatterySensor(propertyName, "WFC02 Battery", propertyValue, true);
                 case "capacity":


### PR DESCRIPTION
## Summary
Two HA `device_class`/unit mismatch warnings surfaced during smoke testing, both causing entities to fail registration or warn. Same class of bug (gateway value/unit not HA-canonical), two subsystems.

### 1. Livedata rain rate `mm/Hr` → `mm/h`
Livedata is unit-passthrough — it forwards the gateway's literal unit to HA. `rrain_piezo` came through as `"mm/Hr"` with `device_class: precipitation_intensity`, which HA rejects (requires `mm/h`), so the sensor failed to register. Consolidated the previously scattered normalizations (`NormalizeTemperatureUnit` + a hardcoded `W/m²`) into one `CanonicalizeUnit` map: `C`/`F`→`°C`/`°F`, `W/m2`→`W/m²`, `mm/Hr`/`in/Hr`→`mm/h`/`in/h`. Everything else passes through. Push path was unaffected (hardcodes `mm/h`).

### 2. Subdevice `wfc02rssi` signal_strength with no unit
`wfc02rssi` is a 0–4 quality *level* (not dBm), but was tagged `device_class: signal_strength`, which HA requires `dBm`/`dB` for → unitless warning. Dropped the device class (now a plain diagnostic int). `gw_rssi` (a real dBm value) keeps `signal_strength` + `dBm`.

## Tests
- `mm/Hr → mm/h` (metric) and `in/Hr → in/h` (imperial) for `rrain_piezo`; existing `mm`/`in` rain-value passthrough stays green.
- `wfc02rssi` → no device class, empty unit, diagnostic category.
- Full suite 177/177.

## Scope
Independent of the valve run-modes work (separate branch off main). Both fixes affect users today (livedata rain rate; any WFC02 subdevice).