### PR TITLE
feat: expose valve/subdevice run modes (duration/volume) in Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A .NET 10 bridge that connects Ecowitt weather stations and IoT subdevices to MQ
 - Two ingestion modes per gateway: **Push** (legacy `/data/report`, works with any Ecowitt-protocol station) or **Poll** (`get_livedata_info` API, for IoT-capable gateways)
 - Automatic discovery of new sensors and subdevices
 - Bidirectional communication with subdevices (AC1100, WFC01, WFC02)
-- Home Assistant MQTT discovery (devices, sensors, switches)
+- Valve/plug run modes in Home Assistant — duration or volume runs that the **device self-closes** (no fragile HA timers), exposed as select + number + button entities, capability-gated per device
+- Home Assistant MQTT discovery (devices, sensors, switches, numbers, selects, buttons)
 - Metric/imperial unit conversion (Push mode) — Poll mode passes the gateway's configured display unit through to HA verbatim
 - Change-detection filtering to reduce MQTT noise
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,29 @@ flowchart LR
     HTTP -->|POST /parse_quick_cmd_iot| GW[Ecowitt Gateway]
 ```
 
+### Run modes (duration / volume)
+
+The valve/plug run-mode entities (`select` + `number` + `button`) feed a separate
+staging path. `MqttService` translates each entity change into a `SubdeviceRunConfig`
+message; `Dispatcher` merges it into the subdevice's `StagedRunConfig` (held in
+`DeviceStore`) and, on the Start button, validates mode applicability + value
+bounds, assembles a `SubdeviceApiCommand`, and routes it through the **same shared
+guard** as the direct path before dispatch. Capability gating (Duration universal;
+Volume only for flow-capable valves) and the unit→gateway conversion
+(minutes→seconds `val_type:0`, liters→deciliters `val_type:3`) are enforced
+controller-side so the device self-closes at the target — the direct-MQTT path
+cannot bypass them.
+
+```mermaid
+flowchart LR
+    HA[HA select / number / button] -->|MQTT cmd/#| MQTT[MqttService]
+    MQTT -->|SubdeviceRunConfig| BUS[(Message Bus)]
+    BUS --> DISP[Dispatcher]
+    DISP -->|merge -> DeviceStore staged config| DISP
+    DISP -->|on Start: guard + SubdeviceCommandDispatch| BUS
+    BUS --> HTTP[HttpPublishingService]
+```
+
 ## Per-gateway Concurrency
 
 All HTTP traffic to a given gateway — subdevice polling, livedata polling (when in Poll mode), and command dispatch — runs through `HttpPublishingService` and serializes through a `ConcurrentDictionary<string, SemaphoreSlim>` keyed by gateway IP. At most one HTTP request per gateway is in flight at any moment. Different gateways still get full parallelism. A separate 350ms `Task.Delay` between subdevice payload calls handles rate-limiting (a separate contract from concurrency).
@@ -100,7 +123,12 @@ flowchart LR
     MQTT --> MCE[mqtt-connection-event] --> DISP
     MQTT --> HAS[home-assistant-status] --> DISP
     MQTT --> SAC[subdevice-api-command] --> DISP
+    MQTT --> SRC[subdevice-run-config] --> DISP
 ```
+
+`subdevice-api-command` carries the HA switch (ON/OFF) and direct-MQTT commands.
+`subdevice-run-config` carries the run-mode entities (select/number/button) as
+partial staged-config updates plus a Start flag.
 
 ### Dispatcher to HttpPublishingService
 
@@ -130,10 +158,10 @@ flowchart LR
 ASP.NET endpoint at `POST /data/report`. Receives form-encoded weather data from Push-mode gateways and publishes `GatewayApiData` onto the bus. For Poll-mode gateways, the request is accepted (200 OK) but the payload is dropped by Dispatcher at the bus boundary — no DataController logic needs to know about IngestMode.
 
 ### Dispatcher
-Central orchestrator. Consumes messages from both HTTP and MQTT services, manages the `DeviceStore` (thread-safe in-memory state), performs change detection via `DeNoiserHelper`, and emits data and discovery messages. For Poll-mode gateways it also drops any incoming `GatewayApiData` push payload (the IngestMode filter lives here, not in DataController). Split across partial classes for HTTP consumers, MQTT consumers, and orchestration logic.
+Central orchestrator. Consumes messages from both HTTP and MQTT services, manages the `DeviceStore` (thread-safe in-memory state), performs change detection via `DeNoiserHelper`, and emits data and discovery messages. For Poll-mode gateways it also drops any incoming `GatewayApiData` push payload (the IngestMode filter lives here, not in DataController). Owns run-mode policy: stages `SubdeviceRunConfig` updates onto the subdevice, validates mode applicability + value bounds in a shared guard (so the direct-MQTT path can't bypass the HA-side constraints), and fires the assembled command on Start. Split across partial classes for HTTP consumers, MQTT consumers, and orchestration logic.
 
 ### MqttService
-Connects to the MQTT broker, publishes sensor data and Home Assistant discovery payloads, subscribes to HA status topic for re-emission on HA restart, and forwards subdevice commands from HA switches onto the bus as `SubdeviceApiCommand` messages. Split across partial classes for consumer, publisher, discovery, and events.
+Connects to the MQTT broker, publishes sensor data and Home Assistant discovery payloads (including the run-mode `select`/`number`/`button` entities for controllable subdevices), subscribes to HA status topic for re-emission on HA restart, and forwards subdevice commands onto the bus — HA switch / direct JSON as `SubdeviceApiCommand`, and run-mode entity changes as `SubdeviceRunConfig`. A single `<base>/+/subdevices/+/cmd/#` subscription covers all subdevice command topics. Split across partial classes for consumer, publisher, discovery, and events.
 
 ### HttpPublishingService
 Owns all outbound HTTP traffic to gateways. Runs two `PeriodicTimer` loops in parallel — one for subdevice polling (`get_iot_device_list` + `parse_quick_cmd_iot`), one for livedata polling (`get_livedata_info`) on Poll-mode gateways — plus a `SubdeviceCommandDispatch` bus consumer that issues start/stop commands. All three call sites acquire a per-gateway `SemaphoreSlim` to serialize requests to the same device.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -63,10 +63,13 @@ Same payload format as gateway sensors.
 
 ### Subdevice Commands (direct MQTT)
 - **`<base>/+/subdevices/+/cmd`** — Accepts JSON commands for subdevice control.
-  ```json
-  { "cmd": 0, "id": 12345, "duration": 20, "unit": 1, "alwaysOn": false }
+  ```jsonc
+  { "cmd": "Start", "id": 12345, "duration": 20, "unit": "Minutes" }
+  // cmd: Start | Stop. unit: Seconds | Minutes | Hours | Liters (or 0|1|2|3).
+  // duration is in the chosen unit; the controller normalizes time to seconds
+  // and volume to deciliters for the gateway. Omit duration/unit for an
+  // always-on Start.
   ```
-  `cmd`: `0` = Start, `1` = Stop. `unit`: `0` = Seconds, `1` = Minutes, `2` = Hours, `3` = Liters.
 
 ### Subdevice Commands (Home Assistant)
 - **`<base>/+/subdevices/+/cmd/homeassistant`** — Simplified command topic for HA switches. Payload is plain text `ON` or `OFF`.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -72,7 +72,17 @@ Same payload format as gateway sensors.
   ```
 
 ### Subdevice Commands (Home Assistant)
-- **`<base>/+/subdevices/+/cmd/homeassistant`** — Simplified command topic for HA switches. Payload is plain text `ON` or `OFF`.
+- **`<base>/+/subdevices/+/cmd/homeassistant`** — Simplified command topic for HA switches. Payload is plain text `ON` or `OFF` (always-on run / stop).
+
+### Subdevice Run Modes (Home Assistant)
+Controllable subdevices (WFC01/WFC02/AC1100) expose duration/volume run controls in addition to the on/off switch. The controller **stages** the selected mode and value, then fires the run when the Start button is pressed — the device self-closes at the duration/volume target.
+
+- **`<base>/+/subdevices/+/cmd/mode`** — selected run mode. Payload: `Duration` or `Volume`.
+- **`<base>/+/subdevices/+/cmd/set/duration`** — run duration in minutes (plain integer).
+- **`<base>/+/subdevices/+/cmd/set/volume`** — run volume in liters (plain integer; flow-capable valves only).
+- **`<base>/+/subdevices/+/cmd/start`** — start a run using the currently staged mode + value.
+
+All subdevice command topics (the four above plus `cmd` and `cmd/homeassistant`) are covered by a single `<base>/+/subdevices/+/cmd/#` subscription. A run mode the device doesn't support (e.g. `Volume` on a flow-less valve) is rejected; a `Start` with a missing/invalid value falls back to a safe default (3 min / 5 L).
 
 ## Home Assistant Discovery
 
@@ -83,6 +93,9 @@ When `controller.homeassistantdiscovery` is enabled, discovery configs are publi
 - **`homeassistant/sensor/<device_name>_<sensor_name>/config`** — Sensor entities
 - **`homeassistant/binary_sensor/<device_name>_<sensor_name>/config`** — Binary sensor entities (rain state, running state, etc.)
 - **`homeassistant/switch/<subdevice_nickname>/config`** — Switch entities for controllable subdevices
+- **`homeassistant/number/<subdevice_nickname>_<param>/config`** — Run Duration / Run Volume inputs (`entity_category: config`)
+- **`homeassistant/select/<subdevice_nickname>/config`** — Run Mode selector (published only when 2+ modes apply)
+- **`homeassistant/button/<subdevice_nickname>/config`** — Start Run button
 
 ### Discovery Payload Structure
 

--- a/src/EcoWitt.Controller.Tests/DiscoveryBuilderTest.cs
+++ b/src/EcoWitt.Controller.Tests/DiscoveryBuilderTest.cs
@@ -142,6 +142,51 @@ public class DiscoveryBuilderTest
         Assert.That(config.StateTopic, Does.Contain("running"));
     }
 
+    [Test]
+    public void BuildNumberConfig_SetsRangeAndCommandTopic()
+    {
+        var device = DiscoveryBuilder.BuildDevice("valve");
+        var origin = DiscoveryBuilder.BuildOrigin();
+
+        var cfg = DiscoveryBuilder.BuildNumberConfig(device, origin, "Run Duration", "id_dur",
+            commandTopic: "ecowitt/gw/subdevices/1/cmd/set/duration",
+            min: 1, max: 1440, step: 1, unitOfMeasurement: "min", entityCategory: "config");
+
+        Assert.That(cfg.CommandTopic, Is.EqualTo("ecowitt/gw/subdevices/1/cmd/set/duration"));
+        Assert.That(cfg.Min, Is.EqualTo(1));
+        Assert.That(cfg.Max, Is.EqualTo(1440));
+        Assert.That(cfg.Step, Is.EqualTo(1));
+        Assert.That(cfg.UnitOfMeasurement, Is.EqualTo("min"));
+        Assert.That(cfg.SensorCategory, Is.EqualTo("config"));
+    }
+
+    [Test]
+    public void BuildSelectConfig_SetsOptions()
+    {
+        var device = DiscoveryBuilder.BuildDevice("valve");
+        var origin = DiscoveryBuilder.BuildOrigin();
+
+        var cfg = DiscoveryBuilder.BuildSelectConfig(device, origin, "Run Mode", "id_mode",
+            commandTopic: "ecowitt/gw/subdevices/1/cmd/mode",
+            options: new List<string> { "Duration", "Volume" });
+
+        Assert.That(cfg.Options, Is.EqualTo(new List<string> { "Duration", "Volume" }));
+        Assert.That(cfg.CommandTopic, Is.EqualTo("ecowitt/gw/subdevices/1/cmd/mode"));
+    }
+
+    [Test]
+    public void BuildButtonConfig_SetsPayloadPress()
+    {
+        var device = DiscoveryBuilder.BuildDevice("valve");
+        var origin = DiscoveryBuilder.BuildOrigin();
+
+        var cfg = DiscoveryBuilder.BuildButtonConfig(device, origin, "Start Run", "id_start",
+            commandTopic: "ecowitt/gw/subdevices/1/cmd/start", payloadPress: "PRESS");
+
+        Assert.That(cfg.PayloadPress, Is.EqualTo("PRESS"));
+        Assert.That(cfg.CommandTopic, Is.EqualTo("ecowitt/gw/subdevices/1/cmd/start"));
+    }
+
     // Device class mapping
     [TestCase(SensorType.Temperature, "temperature")]
     [TestCase(SensorType.Humidity, "humidity")]

--- a/src/EcoWitt.Controller.Tests/DispatcherGuardTest.cs
+++ b/src/EcoWitt.Controller.Tests/DispatcherGuardTest.cs
@@ -1,0 +1,62 @@
+using Ecowitt.Controller.Model.Api;
+using Ecowitt.Controller.Service.Orchestrator;
+using NUnit.Framework;
+
+namespace EcoWitt.Controller.Tests;
+
+[TestFixture]
+public class DispatcherGuardTest
+{
+    [Test]
+    public void Guard_DurationUnset_DefaultsTo3Min()
+    {
+        var cmd = new SubdeviceApiCommand { Cmd = Command.Start, Id = 1, Unit = DurationUnit.Minutes, Duration = null };
+        Dispatcher.GuardRunCommand(cmd);
+        Assert.That(cmd.Duration, Is.EqualTo(3));
+        Assert.That(cmd.AlwaysOn, Is.Not.EqualTo(true));
+    }
+
+    [Test]
+    public void Guard_NegativeDuration_DefaultsTo3Min()
+    {
+        var cmd = new SubdeviceApiCommand { Cmd = Command.Start, Id = 1, Unit = DurationUnit.Minutes, Duration = -1 };
+        Dispatcher.GuardRunCommand(cmd);
+        Assert.That(cmd.Duration, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Guard_HugeDuration_ClampedToMax()
+    {
+        var cmd = new SubdeviceApiCommand { Cmd = Command.Start, Id = 1, Unit = DurationUnit.Minutes, Duration = int.MaxValue };
+        Dispatcher.GuardRunCommand(cmd);
+        Assert.That(cmd.Duration, Is.EqualTo(1440));
+    }
+
+    [Test]
+    public void Guard_VolumeUnset_DefaultsTo5L()
+    {
+        var cmd = new SubdeviceApiCommand { Cmd = Command.Start, Id = 1, Unit = DurationUnit.Liters, Duration = 0 };
+        Dispatcher.GuardRunCommand(cmd);
+        Assert.That(cmd.Duration, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Guard_BareStartNoUnit_StaysAlwaysOn()
+    {
+        // The HA switch ON: Start, no Unit, no Duration → always-on, NOT defaulted to a duration run.
+        var cmd = new SubdeviceApiCommand { Cmd = Command.Start, Id = 1, Unit = null, Duration = null };
+        Dispatcher.GuardRunCommand(cmd);
+        Assert.That(cmd.AlwaysOn, Is.True);
+        Assert.That(cmd.Duration, Is.Null);
+    }
+
+    [Test]
+    public void Guard_Stop_Untouched()
+    {
+        var cmd = new SubdeviceApiCommand { Cmd = Command.Stop, Id = 1 };
+        Dispatcher.GuardRunCommand(cmd);
+        Assert.That(cmd.AlwaysOn, Is.Not.EqualTo(true));
+        Assert.That(cmd.Duration, Is.Null);
+    }
+
+}

--- a/src/EcoWitt.Controller.Tests/DispatcherMergeTest.cs
+++ b/src/EcoWitt.Controller.Tests/DispatcherMergeTest.cs
@@ -1,0 +1,268 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ecowitt.Controller.Model;
+using Ecowitt.Controller.Model.Api;
+using Ecowitt.Controller.Model.Configuration;
+using Ecowitt.Controller.Model.Message.Data;
+using Ecowitt.Controller.Service.Orchestrator;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using SlimMessageBus;
+
+namespace EcoWitt.Controller.Tests;
+
+/// <summary>
+/// Tests for Dispatcher.OnHandle(SubdeviceRunConfig) — staged config merge,
+/// assembly into SubdeviceApiCommand, and edge-case guard paths.
+/// Spec reference: docs/specs/2026-06-03-valve-run-modes-design.md lines 332–335.
+/// </summary>
+[TestFixture]
+public class DispatcherMergeTest
+{
+    // ------------------------------------------------------------------
+    // Fakes
+    // ------------------------------------------------------------------
+
+    private sealed class FakeDeviceStore : IDeviceStore
+    {
+        private readonly Dictionary<string, Device> _store = new();
+
+        public void Seed(Device device) => _store[device.IpAddress] = device;
+
+        public Device? GetGateway(string ipAddress)
+            => _store.TryGetValue(ipAddress, out var gw) ? gw : null;
+
+        public Device? GetGatewayBySubdeviceId(int id)
+            => _store.Values.FirstOrDefault(g => g.Subdevices.Any(s => s.Id == id));
+
+        public bool UpsertGateway(Device data)
+        {
+            _store[data.IpAddress] = data;
+            return true;
+        }
+
+        public void Clear() => _store.Clear();
+
+        public Dictionary<string, string?> GetGatewaysShort()
+            => _store.ToDictionary(kv => kv.Key, kv => kv.Value.Model);
+    }
+
+    private sealed class CapturingMessageBus : IMessageBus
+    {
+        public readonly List<object> Published = new();
+
+        public Task Publish<TMessage>(TMessage message, string? path = null,
+            IDictionary<string, object>? headers = null,
+            CancellationToken cancellationToken = default)
+        {
+            Published.Add(message!);
+            return Task.CompletedTask;
+        }
+
+        // Request/response stubs — not used by Dispatcher but required by the interface.
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, string? path = null,
+            IDictionary<string, object>? headers = null, TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send(IRequest request, string? path = null,
+            IDictionary<string, object>? headers = null, TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<TResponse> Send<TResponse, TRequest>(TRequest request, string? path = null,
+            IDictionary<string, object>? headers = null, TimeSpan? timeout = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static Dispatcher BuildDispatcher(FakeDeviceStore store, CapturingMessageBus bus)
+    {
+        var logger = NullLogger<Dispatcher>.Instance;
+        return new Dispatcher(
+            logger,
+            store,
+            bus,
+            Options.Create(new MqttOptions()),
+            Options.Create(new EcowittOptions()),
+            Options.Create(new ControllerOptions()));
+    }
+
+    private static (FakeDeviceStore store, CapturingMessageBus bus, Dispatcher dispatcher, Subdevice subdevice)
+        SetupWfc02()
+    {
+        var store = new FakeDeviceStore();
+        var bus = new CapturingMessageBus();
+        var dispatcher = BuildDispatcher(store, bus);
+
+        var subdevice = new Subdevice
+        {
+            Id = 99,
+            Model = SubdeviceModel.WFC02,
+            HasFlowMeter = true,
+            GwIp = "192.168.1.10",
+            Nickname = "WFC02-test",
+            Devicename = "WFC02",
+            StagedRunConfig = new StagedRunConfig() // defaults: Mode=Duration, DurationMinutes=3, VolumeLiters=5
+        };
+
+        var gateway = new Device
+        {
+            IpAddress = "192.168.1.10",
+            Name = "test-gateway",
+            Subdevices = new List<Subdevice> { subdevice }
+        };
+
+        store.Seed(gateway);
+        return (store, bus, dispatcher, subdevice);
+    }
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    [Test]
+    public async Task Merge_PartialUpdates_ApplyToStagedConfig()
+    {
+        var (_, _, dispatcher, subdevice) = SetupWfc02();
+
+        // Set mode to Volume
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Mode = RunModeKey.Volume, Start = false },
+            CancellationToken.None);
+
+        Assert.That(subdevice.StagedRunConfig.Mode, Is.EqualTo(RunModeKey.Volume));
+
+        // Set volume to 10 L
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Volume = 10, Start = false },
+            CancellationToken.None);
+
+        Assert.That(subdevice.StagedRunConfig.VolumeLiters, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task Start_DurationMode_EmitsCorrectCommand()
+    {
+        var (_, bus, dispatcher, subdevice) = SetupWfc02();
+        subdevice.StagedRunConfig.Mode = RunModeKey.Duration;
+        subdevice.StagedRunConfig.DurationMinutes = 7;
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Start = true },
+            CancellationToken.None);
+
+        var dispatch = bus.Published.OfType<SubdeviceCommandDispatch>().Single();
+        Assert.That(dispatch.Command.Cmd, Is.EqualTo(Command.Start));
+        Assert.That(dispatch.Command.Unit, Is.EqualTo(DurationUnit.Minutes));
+        Assert.That(dispatch.Command.Duration, Is.EqualTo(7));
+        Assert.That(dispatch.GatewayIp, Is.EqualTo("192.168.1.10"));
+        Assert.That(dispatch.Model, Is.EqualTo(SubdeviceModel.WFC02));
+    }
+
+    [Test]
+    public async Task Start_VolumeMode_EmitsCorrectCommand()
+    {
+        var (_, bus, dispatcher, subdevice) = SetupWfc02();
+        subdevice.StagedRunConfig.Mode = RunModeKey.Volume;
+        subdevice.StagedRunConfig.VolumeLiters = 15;
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Start = true },
+            CancellationToken.None);
+
+        var dispatch = bus.Published.OfType<SubdeviceCommandDispatch>().Single();
+        Assert.That(dispatch.Command.Cmd, Is.EqualTo(Command.Start));
+        Assert.That(dispatch.Command.Unit, Is.EqualTo(DurationUnit.Liters));
+        Assert.That(dispatch.Command.Duration, Is.EqualTo(15));
+    }
+
+    [Test]
+    public async Task Start_MergedVolumeMode_ThenFire_EmitsAssembledCommand()
+    {
+        // Spec: feed SubdeviceRunConfig partials (mode, then volume), then Start=true
+        // → Dispatcher emits the correct SubdeviceApiCommand from the staged config.
+        var (_, bus, dispatcher, _) = SetupWfc02();
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Mode = RunModeKey.Volume, Start = false },
+            CancellationToken.None);
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Volume = 20, Start = false },
+            CancellationToken.None);
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Start = true },
+            CancellationToken.None);
+
+        var dispatches = bus.Published.OfType<SubdeviceCommandDispatch>().ToList();
+        Assert.That(dispatches, Has.Count.EqualTo(1));
+        var cmd = dispatches[0].Command;
+        Assert.That(cmd.Unit, Is.EqualTo(DurationUnit.Liters));
+        Assert.That(cmd.Duration, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task Start_ZeroDurationInStagedConfig_WarnsAndDoesNotDispatch()
+    {
+        // Spec: selected-mode input of 0 → warning, no dispatch.
+        // When staged DurationMinutes = 0, Start must be suppressed (not silently defaulted).
+        var (_, bus, dispatcher, subdevice) = SetupWfc02();
+        subdevice.StagedRunConfig.Mode = RunModeKey.Duration;
+        subdevice.StagedRunConfig.DurationMinutes = 0; // explicitly bad value
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Start = true },
+            CancellationToken.None);
+
+        var dispatches = bus.Published.OfType<SubdeviceCommandDispatch>().ToList();
+        Assert.That(dispatches, Is.Empty, "Zero duration must not be dispatched");
+    }
+
+    [Test]
+    public async Task Start_ZeroVolumeInStagedConfig_WarnsAndDoesNotDispatch()
+    {
+        // Spec: selected-mode input of 0 → warning, no dispatch (volume variant).
+        var (_, bus, dispatcher, subdevice) = SetupWfc02();
+        subdevice.StagedRunConfig.Mode = RunModeKey.Volume;
+        subdevice.StagedRunConfig.VolumeLiters = 0; // explicitly bad value
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Start = true },
+            CancellationToken.None);
+
+        var dispatches = bus.Published.OfType<SubdeviceCommandDispatch>().ToList();
+        Assert.That(dispatches, Is.Empty, "Zero volume must not be dispatched");
+    }
+
+    [Test]
+    public async Task UnknownSubdevice_LogsWarningAndDoesNotDispatch()
+    {
+        var (_, bus, dispatcher, _) = SetupWfc02();
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 999, Start = true },
+            CancellationToken.None);
+
+        Assert.That(bus.Published.OfType<SubdeviceCommandDispatch>(), Is.Empty);
+    }
+
+    [Test]
+    public async Task NoStart_DoesNotDispatch()
+    {
+        var (_, bus, dispatcher, _) = SetupWfc02();
+
+        await dispatcher.OnHandle(
+            new SubdeviceRunConfig { Id = 99, Duration = 10, Start = false },
+            CancellationToken.None);
+
+        Assert.That(bus.Published.OfType<SubdeviceCommandDispatch>(), Is.Empty);
+    }
+}

--- a/src/EcoWitt.Controller.Tests/MqttPathBuilderTest.cs
+++ b/src/EcoWitt.Controller.Tests/MqttPathBuilderTest.cs
@@ -108,4 +108,18 @@ public class MqttPathBuilderTest
     {
         Assert.That(MqttPathBuilder.SanitizeSegment("a/b+c#d E"), Is.EqualTo("a-b-c-d-e"));
     }
+
+    [Test]
+    public void BuildSubdeviceCommandSubtree_IsWildcard()
+    {
+        Assert.That(MqttPathBuilder.BuildMqttSubdeviceCommandSubtree(), Is.EqualTo("+/subdevices/+/cmd/#"));
+    }
+
+    [Test]
+    public void BuildSubdeviceRunTopics_AreUnderCmdSubtree()
+    {
+        Assert.That(MqttPathBuilder.BuildMqttSubdeviceModeTopic("gw", "1"), Is.EqualTo("gw/subdevices/1/cmd/mode"));
+        Assert.That(MqttPathBuilder.BuildMqttSubdeviceSetTopic("gw", "1", "duration"), Is.EqualTo("gw/subdevices/1/cmd/set/duration"));
+        Assert.That(MqttPathBuilder.BuildMqttSubdeviceStartTopic("gw", "1"), Is.EqualTo("gw/subdevices/1/cmd/start"));
+    }
 }

--- a/src/EcoWitt.Controller.Tests/RunModeTest.cs
+++ b/src/EcoWitt.Controller.Tests/RunModeTest.cs
@@ -62,4 +62,16 @@ public class RunModeTest
         var modes = RunModeRegistry.ApplicableModes(SubdeviceModel.AC1100, hasFlowMeter: false);
         Assert.That(modes.Select(m => m.Key), Is.EqualTo(new[] { RunModeKey.Duration }));
     }
+
+    [Test]
+    public void IsApplicable_GatesVolumeByCapability()
+    {
+        // Duration is universal for controllable devices.
+        Assert.That(RunModeRegistry.IsApplicable(SubdeviceModel.AC1100, hasFlowMeter: false, RunModeKey.Duration), Is.True);
+        // Volume requires flow: AC1100 never; WFC02 only with flow; WFC01 always.
+        Assert.That(RunModeRegistry.IsApplicable(SubdeviceModel.AC1100, hasFlowMeter: false, RunModeKey.Volume), Is.False);
+        Assert.That(RunModeRegistry.IsApplicable(SubdeviceModel.WFC02, hasFlowMeter: false, RunModeKey.Volume), Is.False);
+        Assert.That(RunModeRegistry.IsApplicable(SubdeviceModel.WFC02, hasFlowMeter: true, RunModeKey.Volume), Is.True);
+        Assert.That(RunModeRegistry.IsApplicable(SubdeviceModel.WFC01, hasFlowMeter: false, RunModeKey.Volume), Is.True);
+    }
 }

--- a/src/EcoWitt.Controller.Tests/RunModeTest.cs
+++ b/src/EcoWitt.Controller.Tests/RunModeTest.cs
@@ -1,0 +1,65 @@
+using Ecowitt.Controller.Model;
+using Ecowitt.Controller.Model.Api;
+using NUnit.Framework;
+
+namespace EcoWitt.Controller.Tests;
+
+[TestFixture]
+public class RunModeTest
+{
+    [Test]
+    public void Registry_Duration_HasMinutesUnitAndDefaults()
+    {
+        var m = RunModeRegistry.ByKey(RunModeKey.Duration);
+        Assert.That(m.Unit, Is.EqualTo(DurationUnit.Minutes));
+        Assert.That(m.Min, Is.EqualTo(1));
+        Assert.That(m.Max, Is.EqualTo(1440));
+        Assert.That(m.Default, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void Registry_Volume_HasLitersUnitAndDefaults()
+    {
+        var m = RunModeRegistry.ByKey(RunModeKey.Volume);
+        Assert.That(m.Unit, Is.EqualTo(DurationUnit.Liters));
+        Assert.That(m.Min, Is.EqualTo(1));
+        Assert.That(m.Max, Is.EqualTo(1000));
+        Assert.That(m.Default, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Capability_AC1100_DurationOnly()
+    {
+        Assert.That(RunModeRegistry.SupportsDuration(SubdeviceModel.AC1100), Is.True);
+        Assert.That(RunModeRegistry.SupportsVolume(SubdeviceModel.AC1100, hasFlowMeter: false), Is.False);
+    }
+
+    [Test]
+    public void Capability_WFC01_DurationAndVolume()
+    {
+        Assert.That(RunModeRegistry.SupportsDuration(SubdeviceModel.WFC01), Is.True);
+        // WFC01 always has flow regardless of the reported flag
+        Assert.That(RunModeRegistry.SupportsVolume(SubdeviceModel.WFC01, hasFlowMeter: false), Is.True);
+    }
+
+    [Test]
+    public void Capability_WFC02_VolumeGatedByFlowMeter()
+    {
+        Assert.That(RunModeRegistry.SupportsVolume(SubdeviceModel.WFC02, hasFlowMeter: true), Is.True);
+        Assert.That(RunModeRegistry.SupportsVolume(SubdeviceModel.WFC02, hasFlowMeter: false), Is.False);
+    }
+
+    [Test]
+    public void ApplicableModes_WFC02WithFlow_DurationThenVolume()
+    {
+        var modes = RunModeRegistry.ApplicableModes(SubdeviceModel.WFC02, hasFlowMeter: true);
+        Assert.That(modes.Select(m => m.Key), Is.EqualTo(new[] { RunModeKey.Duration, RunModeKey.Volume }));
+    }
+
+    [Test]
+    public void ApplicableModes_AC1100_DurationOnly()
+    {
+        var modes = RunModeRegistry.ApplicableModes(SubdeviceModel.AC1100, hasFlowMeter: false);
+        Assert.That(modes.Select(m => m.Key), Is.EqualTo(new[] { RunModeKey.Duration }));
+    }
+}

--- a/src/EcoWitt.Controller.Tests/SubdeviceCommandConversionTest.cs
+++ b/src/EcoWitt.Controller.Tests/SubdeviceCommandConversionTest.cs
@@ -1,0 +1,41 @@
+using Ecowitt.Controller.Model.Api;
+using Ecowitt.Controller.Service.Http;
+using NUnit.Framework;
+
+namespace EcoWitt.Controller.Tests;
+
+[TestFixture]
+public class SubdeviceCommandConversionTest
+{
+    [Test]
+    public void Convert_Minutes_ToSecondsValType0()
+    {
+        var (valType, val) = HttpPublishingService.ToGatewayRun(10, DurationUnit.Minutes);
+        Assert.That(valType, Is.EqualTo(0));
+        Assert.That(val, Is.EqualTo(600));   // 10 min = 600 s
+    }
+
+    [Test]
+    public void Convert_Seconds_PassThroughValType0()
+    {
+        var (valType, val) = HttpPublishingService.ToGatewayRun(180, DurationUnit.Seconds);
+        Assert.That(valType, Is.EqualTo(0));
+        Assert.That(val, Is.EqualTo(180));
+    }
+
+    [Test]
+    public void Convert_Hours_ToSecondsValType0()
+    {
+        var (valType, val) = HttpPublishingService.ToGatewayRun(1, DurationUnit.Hours);
+        Assert.That(valType, Is.EqualTo(0));
+        Assert.That(val, Is.EqualTo(3600));
+    }
+
+    [Test]
+    public void Convert_Liters_ToDeciliterValType3()
+    {
+        var (valType, val) = HttpPublishingService.ToGatewayRun(5, DurationUnit.Liters);
+        Assert.That(valType, Is.EqualTo(3));
+        Assert.That(val, Is.EqualTo(50));    // 5 L = 50 dL
+    }
+}

--- a/src/EcoWitt.Controller.Tests/SubdeviceMappingTest.cs
+++ b/src/EcoWitt.Controller.Tests/SubdeviceMappingTest.cs
@@ -104,12 +104,12 @@ public class SubdeviceMappingTest
         }
 
         Assert.That(subdevices, Has.Count.EqualTo(2));
-        
+
         var wfc = subdevices.FirstOrDefault(sd => sd.Model == 1);
         Assert.That(wfc.Payload, Is.EqualTo(json_device_wfc));
-        
+
         var subDevice = wfc.Map();
-        
+
         Assert.That(subDevice.Id, Is.EqualTo(13398));
         Assert.That(subDevice.Model, Is.EqualTo(SubdeviceModel.WFC01));
         Assert.That(subDevice.Version, Is.EqualTo(113));
@@ -117,5 +117,49 @@ public class SubdeviceMappingTest
         Assert.That(subDevice.Nickname, Is.EqualTo("WFC01-00003456"));
         Assert.That(subDevice.Availability, Is.EqualTo(true));
         Assert.That(subDevice.Sensors, Has.Count.EqualTo(15));
+    }
+
+    [Test]
+    public void Map_WFC02_ParsesFlowMeterCapability()
+    {
+        var apiData = new Ecowitt.Controller.Model.Api.SubdeviceApiData
+        {
+            Id = 11131, Model = 3, GwIp = "192.168.0.1",
+            Payload = "{\"command\":[{\"model\":3,\"id\":11131,\"nickname\":\"WFC02-X\",\"flowmeter\":1,\"valve\":1}]}"
+        };
+
+        var sd = apiData.Map(isMetric: true, calculateValues: false);
+
+        Assert.That(sd.HasFlowMeter, Is.True);
+    }
+
+    [Test]
+    public void Map_AC1100_NoFlowMeterField_DefaultsFalse()
+    {
+        var apiData = new Ecowitt.Controller.Model.Api.SubdeviceApiData
+        {
+            Id = 10695, Model = 2, GwIp = "192.168.0.1",
+            Payload = "{\"command\":[{\"model\":2,\"id\":10695,\"nickname\":\"AC1100-X\",\"always_on\":1}]}"
+        };
+
+        var sd = apiData.Map(isMetric: true, calculateValues: false);
+
+        Assert.That(sd.HasFlowMeter, Is.False);
+    }
+
+    [Test]
+    public void Map_StagedRunConfig_InitializesToDefaults()
+    {
+        var apiData = new Ecowitt.Controller.Model.Api.SubdeviceApiData
+        {
+            Id = 11131, Model = 3, GwIp = "192.168.0.1",
+            Payload = "{\"command\":[{\"model\":3,\"id\":11131,\"nickname\":\"WFC02-X\",\"flowmeter\":1}]}"
+        };
+
+        var sd = apiData.Map(isMetric: true, calculateValues: false);
+
+        Assert.That(sd.StagedRunConfig.Mode, Is.EqualTo(Ecowitt.Controller.Model.Api.RunModeKey.Duration));
+        Assert.That(sd.StagedRunConfig.DurationMinutes, Is.EqualTo(3));
+        Assert.That(sd.StagedRunConfig.VolumeLiters, Is.EqualTo(5));
     }
 }

--- a/src/EcoWitt.Controller.Tests/SubdeviceMappingTest.cs
+++ b/src/EcoWitt.Controller.Tests/SubdeviceMappingTest.cs
@@ -131,6 +131,9 @@ public class SubdeviceMappingTest
         var sd = apiData.Map(isMetric: true, calculateValues: false);
 
         Assert.That(sd.HasFlowMeter, Is.True);
+        // flowmeter must also produce the "Flowmeter Available" binary_sensor — not silently dropped
+        Assert.That(sd.Sensors.Any(s => s.Name == "flowmeter"), Is.True,
+            "flowmeter field must produce a sensor via SensorBuilder, not be swallowed by continue");
     }
 
     [Test]

--- a/src/Ecowitt.Controller/Model/Api/RunMode.cs
+++ b/src/Ecowitt.Controller/Model/Api/RunMode.cs
@@ -50,4 +50,14 @@ public static class RunModeRegistry
         if (SupportsVolume(model, hasFlowMeter)) modes.Add(Volume);
         return modes;
     }
+
+    // Is this run mode valid for the device? Enforced in the dispatcher because the direct-MQTT
+    // path can stage a mode the HA select never offered (e.g. Volume on a flow-less valve, which
+    // would run forever with no liters to count — the stuck-open hazard this feature avoids).
+    public static bool IsApplicable(SubdeviceModel model, bool hasFlowMeter, RunModeKey mode) => mode switch
+    {
+        RunModeKey.Duration => SupportsDuration(model),
+        RunModeKey.Volume => SupportsVolume(model, hasFlowMeter),
+        _ => false
+    };
 }

--- a/src/Ecowitt.Controller/Model/Api/RunMode.cs
+++ b/src/Ecowitt.Controller/Model/Api/RunMode.cs
@@ -1,0 +1,53 @@
+using Ecowitt.Controller.Model;
+
+namespace Ecowitt.Controller.Model.Api;
+
+public enum RunModeKey
+{
+    Duration = 0,
+    Volume = 1
+}
+
+public record RunMode(
+    RunModeKey Key,
+    string HaLabel,
+    DurationUnit Unit,
+    int Min,
+    int Max,
+    int Default);
+
+public static class RunModeRegistry
+{
+    // Single source of truth for run-mode bounds/defaults, consumed by HA discovery
+    // (number min/max/initial) and the Dispatcher guard (clamp/default).
+    private static readonly RunMode Duration =
+        new(RunModeKey.Duration, "Duration", DurationUnit.Minutes, 1, 1440, 3);
+    private static readonly RunMode Volume =
+        new(RunModeKey.Volume, "Volume", DurationUnit.Liters, 1, 1000, 5);
+
+    public static RunMode ByKey(RunModeKey key) => key switch
+    {
+        RunModeKey.Duration => Duration,
+        RunModeKey.Volume => Volume,
+        _ => throw new ArgumentOutOfRangeException(nameof(key), key, "unknown run mode")
+    };
+
+    public static bool SupportsDuration(SubdeviceModel model) =>
+        model is SubdeviceModel.WFC01 or SubdeviceModel.WFC02 or SubdeviceModel.AC1100;
+
+    public static bool SupportsVolume(SubdeviceModel model, bool hasFlowMeter) => model switch
+    {
+        SubdeviceModel.WFC01 => true,            // flow built in; not self-reported
+        SubdeviceModel.WFC02 => hasFlowMeter,    // optional flow, self-reported
+        _ => false                                // AC1100 and others: no flow
+    };
+
+    // Modes applicable to a device, in display order.
+    public static IReadOnlyList<RunMode> ApplicableModes(SubdeviceModel model, bool hasFlowMeter)
+    {
+        var modes = new List<RunMode>();
+        if (SupportsDuration(model)) modes.Add(Duration);
+        if (SupportsVolume(model, hasFlowMeter)) modes.Add(Volume);
+        return modes;
+    }
+}

--- a/src/Ecowitt.Controller/Model/Discovery/Config.cs
+++ b/src/Ecowitt.Controller/Model/Discovery/Config.cs
@@ -49,4 +49,17 @@ public class Config
     public string? StateOn { get; set; }
     [JsonPropertyName("state_off")]
     public string? StateOff { get; set; }
+
+    [JsonPropertyName("min")]
+    public double? Min { get; set; }
+    [JsonPropertyName("max")]
+    public double? Max { get; set; }
+    [JsonPropertyName("step")]
+    public double? Step { get; set; }
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+    [JsonPropertyName("options")]
+    public List<string>? Options { get; set; }
+    [JsonPropertyName("payload_press")]
+    public string? PayloadPress { get; set; }
 }   

--- a/src/Ecowitt.Controller/Model/Discovery/DiscoveryBuilder.cs
+++ b/src/Ecowitt.Controller/Model/Discovery/DiscoveryBuilder.cs
@@ -229,6 +229,69 @@ public static class DiscoveryBuilder
         return result;
     }
 
+    public static Config BuildNumberConfig(Device device, Origin origin, string name, string uniqueId,
+        string commandTopic, double min, double max, double step,
+        string? stateTopic = null, string? unitOfMeasurement = null, string? entityCategory = null,
+        string mode = "box", bool? retain = true, int? qos = 1)
+    {
+        var result = new Config
+        {
+            Device = device,
+            Origin = origin,
+            Name = name,
+            UniqueId = uniqueId,
+            DefaultEntityId = uniqueId,
+            CommandTopic = commandTopic,
+            Min = min,
+            Max = max,
+            Step = step,
+            Mode = mode,
+            Retain = retain,
+            Qos = qos
+        };
+        if (!string.IsNullOrWhiteSpace(stateTopic)) result.StateTopic = stateTopic;
+        if (!string.IsNullOrWhiteSpace(unitOfMeasurement)) result.UnitOfMeasurement = unitOfMeasurement;
+        if (!string.IsNullOrWhiteSpace(entityCategory)) result.SensorCategory = entityCategory;
+        return result;
+    }
+
+    public static Config BuildSelectConfig(Device device, Origin origin, string name, string uniqueId,
+        string commandTopic, List<string> options, string? stateTopic = null,
+        bool? retain = true, int? qos = 1)
+    {
+        var result = new Config
+        {
+            Device = device,
+            Origin = origin,
+            Name = name,
+            UniqueId = uniqueId,
+            DefaultEntityId = uniqueId,
+            CommandTopic = commandTopic,
+            Options = options,
+            Retain = retain,
+            Qos = qos
+        };
+        if (!string.IsNullOrWhiteSpace(stateTopic)) result.StateTopic = stateTopic;
+        return result;
+    }
+
+    public static Config BuildButtonConfig(Device device, Origin origin, string name, string uniqueId,
+        string commandTopic, string payloadPress = "PRESS", bool? retain = false, int? qos = 1)
+    {
+        return new Config
+        {
+            Device = device,
+            Origin = origin,
+            Name = name,
+            UniqueId = uniqueId,
+            DefaultEntityId = uniqueId,
+            CommandTopic = commandTopic,
+            PayloadPress = payloadPress,
+            Retain = retain,
+            Qos = qos
+        };
+    }
+
     public static string BuildIdentifier(string name, string type = "config")
     {
         return $"ec_{name.Replace(' ', '-').ToLowerInvariant()}_{type.Replace(' ', '-').ToLowerInvariant()}";

--- a/src/Ecowitt.Controller/Model/Mapping/ApiDataExtension.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/ApiDataExtension.cs
@@ -53,7 +53,7 @@ public static class ApiDataExtension
                     if (propertyName.Equals("flowmeter", StringComparison.InvariantCultureIgnoreCase))
                     {
                         result.HasFlowMeter = propertyValue.Trim() == "1";
-                        continue;
+                        // fall through: let SensorBuilder also build the "Flowmeter Available" binary_sensor
                     }
 
                     var sensor = SensorBuilder.BuildSensor(propertyName, propertyValue, isMetric);

--- a/src/Ecowitt.Controller/Model/Mapping/ApiDataExtension.cs
+++ b/src/Ecowitt.Controller/Model/Mapping/ApiDataExtension.cs
@@ -49,7 +49,13 @@ public static class ApiDataExtension
                         result.Nickname = propertyValue;
                         continue;
                     }
-                    
+
+                    if (propertyName.Equals("flowmeter", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        result.HasFlowMeter = propertyValue.Trim() == "1";
+                        continue;
+                    }
+
                     var sensor = SensorBuilder.BuildSensor(propertyName, propertyValue, isMetric);
                     if (sensor != null)
                     {

--- a/src/Ecowitt.Controller/Model/Message/Data/SubdeviceRunConfig.cs
+++ b/src/Ecowitt.Controller/Model/Message/Data/SubdeviceRunConfig.cs
@@ -1,0 +1,14 @@
+using Ecowitt.Controller.Model.Api;
+
+namespace Ecowitt.Controller.Model.Message.Data;
+
+// Partial staged-config update from HA entities. Null fields = not updating.
+// Start=true means: assemble + fire using the subdevice's staged config.
+public class SubdeviceRunConfig
+{
+    public int Id { get; set; }
+    public RunModeKey? Mode { get; set; }
+    public int? Duration { get; set; }   // user minutes
+    public int? Volume { get; set; }     // user liters
+    public bool Start { get; set; }
+}

--- a/src/Ecowitt.Controller/Model/Subdevice.cs
+++ b/src/Ecowitt.Controller/Model/Subdevice.cs
@@ -1,3 +1,5 @@
+using Ecowitt.Controller.Model.Api;
+
 namespace Ecowitt.Controller.Model;
 
 public class Subdevice
@@ -19,7 +21,7 @@ public class Subdevice
 public class StagedRunConfig
 {
     // POCO defaults — sensible run config before the user touches anything.
-    public Ecowitt.Controller.Model.Api.RunModeKey Mode { get; set; } = Ecowitt.Controller.Model.Api.RunModeKey.Duration;
+    public RunModeKey Mode { get; set; } = RunModeKey.Duration;
     public int DurationMinutes { get; set; } = 3;
     public int VolumeLiters { get; set; } = 5;
 }

--- a/src/Ecowitt.Controller/Model/Subdevice.cs
+++ b/src/Ecowitt.Controller/Model/Subdevice.cs
@@ -12,6 +12,16 @@ public class Subdevice
     public DateTime TimestampUtc { get; set; }
     public List<ISensor> Sensors { get; set; } = new List<ISensor>();
     public bool DiscoveryUpdate { get; set; }
+    public bool HasFlowMeter { get; set; }
+    public StagedRunConfig StagedRunConfig { get; set; } = new();
+}
+
+public class StagedRunConfig
+{
+    // POCO defaults — sensible run config before the user touches anything.
+    public Ecowitt.Controller.Model.Api.RunModeKey Mode { get; set; } = Ecowitt.Controller.Model.Api.RunModeKey.Duration;
+    public int DurationMinutes { get; set; } = 3;
+    public int VolumeLiters { get; set; } = 5;
 }
 
 public enum SubdeviceModel

--- a/src/Ecowitt.Controller/Program.cs
+++ b/src/Ecowitt.Controller/Program.cs
@@ -118,6 +118,8 @@ public class Program
             // mqttservice -> statemachine (subdevice commands)
             smb.Produce<SubdeviceApiCommand>(x => x.DefaultTopic("subdevice-api-command"));
             smb.Consume<SubdeviceApiCommand>(x => x.Topic("subdevice-api-command").WithConsumer<Dispatcher>());
+            smb.Produce<SubdeviceRunConfig>(x => x.DefaultTopic("subdevice-run-config"));
+            smb.Consume<SubdeviceRunConfig>(x => x.Topic("subdevice-run-config").WithConsumer<Dispatcher>());
 
             smb.AddServicesFromAssembly(Assembly.GetExecutingAssembly());
         });

--- a/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
+++ b/src/Ecowitt.Controller/Service/Http/HttpPublishingService.cs
@@ -152,9 +152,10 @@ public partial class HttpPublishingService : BackgroundService, IHostedLifecycle
             switch (command.Cmd)
             {
                 case Command.Start:
-                    var val = command.Duration ?? 0;
-                    var valType = (int)(command.Unit ?? DurationUnit.Minutes);
                     var alwaysOn = command.AlwaysOn == true || !command.Duration.HasValue ? 1 : 0;
+                    var (valType, val) = alwaysOn == 1
+                        ? (0, 0)
+                        : ToGatewayRun(command.Duration ?? 0, command.Unit ?? DurationUnit.Minutes);
                     payload = new
                     {
                         command = new[]
@@ -199,6 +200,21 @@ public partial class HttpPublishingService : BackgroundService, IHostedLifecycle
         {
             if (acquired) sem.Release();
         }
+    }
+
+    // Maps a user run value + unit to the gateway-native (val_type, val).
+    // Time is always normalized to seconds (val_type=0) — the gateway/app never use val_type 1/2.
+    // Volume is liters in deciliter resolution (val_type=3, val = liters × 10), verified on a WFC02.
+    internal static (int valType, int val) ToGatewayRun(int duration, DurationUnit unit)
+    {
+        return unit switch
+        {
+            DurationUnit.Seconds => (0, duration),
+            DurationUnit.Minutes => (0, duration * 60),
+            DurationUnit.Hours   => (0, duration * 3600),
+            DurationUnit.Liters  => (3, duration * 10),
+            _                    => (0, duration)
+        };
     }
 
     private HttpClient CreateHttpClient(HttpHost host)

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttPathBuilder.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttPathBuilder.cs
@@ -52,6 +52,26 @@ public static class MqttPathBuilder
         return "+/subdevices/+/cmd/homeassistant";
     }
 
+    public static string BuildMqttSubdeviceCommandSubtree()
+    {
+        return "+/subdevices/+/cmd/#";
+    }
+
+    public static string BuildMqttSubdeviceModeTopic(string gwName, string subdeviceName)
+    {
+        return $"{SanitizeSegment(gwName)}/subdevices/{SanitizeSegment(subdeviceName)}/cmd/mode";
+    }
+
+    public static string BuildMqttSubdeviceSetTopic(string gwName, string subdeviceName, string param)
+    {
+        return $"{SanitizeSegment(gwName)}/subdevices/{SanitizeSegment(subdeviceName)}/cmd/set/{SanitizeSegment(param)}";
+    }
+
+    public static string BuildMqttSubdeviceStartTopic(string gwName, string subdeviceName)
+    {
+        return $"{SanitizeSegment(gwName)}/subdevices/{SanitizeSegment(subdeviceName)}/cmd/start";
+    }
+
     public static string SanitizeSegment(string input)
     {
         return input

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.Consumer.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.Consumer.cs
@@ -51,7 +51,7 @@ namespace Ecowitt.Controller.Service.Mqtt
                 optionsBuilder.WithCredentials(_mqttConfig.User, _mqttConfig.Password);
 
             await _client.ConnectAsync(optionsBuilder.Build());
-            await _client.SubscribeAsync($"{_mqttConfig.BaseTopic}/{MqttPathBuilder.BuildMqttSubdeviceCommandTopic()}");
+            await _client.SubscribeAsync($"{_mqttConfig.BaseTopic}/{MqttPathBuilder.BuildMqttSubdeviceCommandSubtree()}");
 
             if (_mqttConfig.HomeAssistantDiscovery) await SubscribeHomeAssistant();
         }

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.DiscoveryPublisher.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.DiscoveryPublisher.cs
@@ -1,5 +1,6 @@
 ﻿
 using Ecowitt.Controller.Model;
+using Ecowitt.Controller.Model.Api;
 using Ecowitt.Controller.Model.Discovery;
 using MQTTnet;
 using MQTTnet.Protocol;
@@ -48,6 +49,58 @@ namespace Ecowitt.Controller.Service.Mqtt
                 DiscoveryBuilder.BuildSwitchConfig(device, _origin, "switch", id, statetopic, cmdTopic, valueTemplate: valueTemplate);
 
             await PublishDiscoveryMessage("switch", $"switch/{MqttPathBuilder.SanitizeSegment(subdevice.Nickname)}", config);
+        }
+
+        private async Task PublishSubdeviceRunModeDiscovery(Device gw, Ecowitt.Controller.Model.Subdevice subdevice)
+        {
+            var modes = RunModeRegistry.ApplicableModes(subdevice.Model, subdevice.HasFlowMeter);
+            if (modes.Count == 0) return;
+
+            var device = DiscoveryBuilder.BuildDevice(subdevice.Nickname, subdevice.Model.ToString(), "Ecowitt",
+                subdevice.Model.ToString(), subdevice.Version.ToString(), DiscoveryBuilder.BuildIdentifier(gw.Name));
+            var baseTopic = $"{_mqttConfig?.BaseTopic}/{MqttPathBuilder.BuildMqttSubdeviceTopic(gw.Name, subdevice.Id.ToString())}";
+            var nick = MqttPathBuilder.SanitizeSegment(subdevice.Nickname);
+
+            // Mode select — only when 2+ modes apply.
+            if (modes.Count > 1)
+            {
+                var selId = DiscoveryBuilder.BuildIdentifier(subdevice.Nickname, "runmode");
+                var selCfg = DiscoveryBuilder.BuildSelectConfig(device, _origin, "Run Mode", selId,
+                    commandTopic: $"{baseTopic}/cmd/mode",
+                    options: modes.Select(m => m.HaLabel).ToList());
+                await PublishDiscoveryMessage("select", $"select/{nick}", selCfg);
+            }
+
+            // One number per applicable mode (config category).
+            foreach (var m in modes)
+            {
+                var param = m.Key == RunModeKey.Volume ? "volume" : "duration";
+                var unit = m.Key == RunModeKey.Volume ? "L" : "min";
+                var numId = DiscoveryBuilder.BuildIdentifier(subdevice.Nickname, $"run{param}");
+                var numCfg = DiscoveryBuilder.BuildNumberConfig(device, _origin, $"Run {m.HaLabel}", numId,
+                    commandTopic: $"{baseTopic}/cmd/set/{param}",
+                    min: m.Min, max: m.Max, step: 1, unitOfMeasurement: unit, entityCategory: "config");
+                await PublishDiscoveryMessage("number", $"number/{nick}_{param}", numCfg);
+            }
+
+            // Start button.
+            var btnId = DiscoveryBuilder.BuildIdentifier(subdevice.Nickname, "runstart");
+            var btnCfg = DiscoveryBuilder.BuildButtonConfig(device, _origin, "Start Run", btnId,
+                commandTopic: $"{baseTopic}/cmd/start");
+            await PublishDiscoveryMessage("button", $"button/{nick}", btnCfg);
+
+            // Publish the CURRENT staged values (retained) so HA reflects them and they survive a
+            // controller restart. Must use the staged config, NOT m.Default — otherwise a discovery
+            // re-emission (e.g. on HA restart) would clobber a user's staged value back to default.
+            var staged = subdevice.StagedRunConfig;
+            if (modes.Count > 1)
+                await Publish($"{baseTopic}/cmd/mode", RunModeRegistry.ByKey(staged.Mode).HaLabel, true);
+            foreach (var m in modes)
+            {
+                var param = m.Key == RunModeKey.Volume ? "volume" : "duration";
+                var current = m.Key == RunModeKey.Volume ? staged.VolumeLiters : staged.DurationMinutes;
+                await Publish($"{baseTopic}/cmd/set/{param}", current.ToString(), true);
+            }
         }
 
         private async Task PublishSensorDiscovery(Device gw, ISensor sensor)

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.Events.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.Events.cs
@@ -1,4 +1,5 @@
 ﻿using Ecowitt.Controller.Model.Api;
+using Ecowitt.Controller.Model.Message.Data;
 using Ecowitt.Controller.Model.Message.Event;
 using MQTTnet;
 using System.Text.Json;
@@ -63,6 +64,29 @@ namespace Ecowitt.Controller.Service.Mqtt
                     _logger.LogWarning("Invalid subdevice id in topic {Topic}", topic);
                 }
             }
+            else if (topic.EndsWith("/cmd/mode"))
+            {
+                if (TryGetSubdeviceId(topic, out var id) &&
+                    Enum.TryParse<RunModeKey>(payload, ignoreCase: true, out var mode))
+                {
+                    await _messageBus.Publish(new SubdeviceRunConfig { Id = id, Mode = mode });
+                }
+            }
+            else if (topic.EndsWith("/cmd/set/duration"))
+            {
+                if (TryGetSubdeviceId(topic, out var id) && int.TryParse(payload, out var minutes))
+                    await _messageBus.Publish(new SubdeviceRunConfig { Id = id, Duration = minutes });
+            }
+            else if (topic.EndsWith("/cmd/set/volume"))
+            {
+                if (TryGetSubdeviceId(topic, out var id) && int.TryParse(payload, out var liters))
+                    await _messageBus.Publish(new SubdeviceRunConfig { Id = id, Volume = liters });
+            }
+            else if (topic.EndsWith("/cmd/start"))
+            {
+                if (TryGetSubdeviceId(topic, out var id))
+                    await _messageBus.Publish(new SubdeviceRunConfig { Id = id, Start = true });
+            }
             else
             {
                 // direct commands via mqtt
@@ -81,6 +105,14 @@ namespace Ecowitt.Controller.Service.Mqtt
                     _logger.LogError(e, "Failed to deserialize command from topic {Topic}: {Payload}", topic, payload);
                 }
             }
+        }
+
+        private static bool TryGetSubdeviceId(string topic, out int id)
+        {
+            id = 0;
+            var parts = topic.Split('/');
+            var idx = Array.IndexOf(parts, "subdevices");
+            return idx >= 0 && idx + 1 < parts.Length && int.TryParse(parts[idx + 1], out id);
         }
 
         private async Task ClientOnDisconnectedAsync(MqttClientDisconnectedEventArgs arg)

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.Events.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.Events.cs
@@ -7,6 +7,11 @@ namespace Ecowitt.Controller.Service.Mqtt
 {
     public partial class MqttService
     {
+        private static readonly System.Text.Json.JsonSerializerOptions CommandJsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
         public async Task StartedAsync(CancellationToken cancellationToken)
         {
             await _messageBus.Publish(new MqttServiceEvent { EventType = MqttServiceEventType.Started }, cancellationToken: cancellationToken);
@@ -63,7 +68,7 @@ namespace Ecowitt.Controller.Service.Mqtt
                 // direct commands via mqtt
                 try
                 {
-                    var cmd = JsonSerializer.Deserialize<SubdeviceApiCommand>(payload);
+                    var cmd = JsonSerializer.Deserialize<SubdeviceApiCommand>(payload, CommandJsonOptions);
                     if (cmd == null)
                     {
                         _logger.LogWarning("Failed to deserialize command from topic {Topic}", topic);

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.cs
@@ -94,6 +94,8 @@ public partial class MqttService : BackgroundService, IHostedLifecycleService, I
             await PublishSubdeviceDiscovery(gateway, subdevice);
             if (subdevice.Model is SubdeviceModel.WFC01 or SubdeviceModel.AC1100 or SubdeviceModel.WFC02)
                 await PublishSubdeviceSwitchDiscovery(gateway, subdevice);
+            if (subdevice.Model is SubdeviceModel.WFC01 or SubdeviceModel.AC1100 or SubdeviceModel.WFC02)
+                await PublishSubdeviceRunModeDiscovery(gateway, subdevice);
             foreach (var sensor in subdevice.Sensors)
             {
                 await PublishSensorDiscovery(gateway, subdevice, sensor);

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.cs
@@ -94,8 +94,7 @@ public partial class MqttService : BackgroundService, IHostedLifecycleService, I
             await PublishSubdeviceDiscovery(gateway, subdevice);
             if (subdevice.Model is SubdeviceModel.WFC01 or SubdeviceModel.AC1100 or SubdeviceModel.WFC02)
                 await PublishSubdeviceSwitchDiscovery(gateway, subdevice);
-            if (subdevice.Model is SubdeviceModel.WFC01 or SubdeviceModel.AC1100 or SubdeviceModel.WFC02)
-                await PublishSubdeviceRunModeDiscovery(gateway, subdevice);
+            await PublishSubdeviceRunModeDiscovery(gateway, subdevice);
             foreach (var sensor in subdevice.Sensors)
             {
                 await PublishSensorDiscovery(gateway, subdevice, sensor);

--- a/src/Ecowitt.Controller/Service/Mqtt/MqttService.cs
+++ b/src/Ecowitt.Controller/Service/Mqtt/MqttService.cs
@@ -66,7 +66,6 @@ public partial class MqttService : BackgroundService, IHostedLifecycleService, I
         }
 
         await _client.SubscribeAsync(HaStatusTopic);
-        await _client.SubscribeAsync($"{_mqttConfig?.BaseTopic}/{MqttPathBuilder.BuildMqttSubdeviceHACommandTopic()}");
         _logger.LogInformation("Subscribed to Home Assistant");
     }
     
@@ -79,7 +78,6 @@ public partial class MqttService : BackgroundService, IHostedLifecycleService, I
         }
 
         await _client.UnsubscribeAsync(HaStatusTopic);
-        await _client.UnsubscribeAsync($"{_mqttConfig?.BaseTopic}/{MqttPathBuilder.BuildMqttSubdeviceHACommandTopic()}");
         _logger.LogInformation("Unsubscribed from Home Assistant");
     }
 

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
@@ -79,6 +79,9 @@ namespace Ecowitt.Controller.Service.Orchestrator
             _ => (1, 86400, 180)
         };
 
+        public Task OnHandle(SubdeviceRunConfig message, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
         public async Task OnHandle(GatewayApiData message, CancellationToken cancellationToken)
         {
             // Drop push payloads from Poll-mode gateways — they get their data via livedata poll instead.

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
@@ -91,7 +91,14 @@ namespace Ecowitt.Controller.Service.Orchestrator
 
             // Merge non-null partials into the staged config. The subdevice is held by reference
             // in the store, so the mutation is visible; UpsertGateway re-stores defensively.
-            if (message.Mode.HasValue) subdevice.StagedRunConfig.Mode = message.Mode.Value;
+            // Reject a mode the device doesn't support (the direct-MQTT path bypasses the HA select).
+            if (message.Mode.HasValue)
+            {
+                if (RunModeRegistry.IsApplicable(subdevice.Model, subdevice.HasFlowMeter, message.Mode.Value))
+                    subdevice.StagedRunConfig.Mode = message.Mode.Value;
+                else
+                    _logger.LogWarning("Ignoring run mode {Mode} for subdevice {Id} ({Model}): not supported by the device", message.Mode.Value, message.Id, subdevice.Model);
+            }
             if (message.Duration.HasValue) subdevice.StagedRunConfig.DurationMinutes = message.Duration.Value;
             if (message.Volume.HasValue) subdevice.StagedRunConfig.VolumeLiters = message.Volume.Value;
             if (!_deviceStore.UpsertGateway(gw))
@@ -102,6 +109,13 @@ namespace Ecowitt.Controller.Service.Orchestrator
             if (!message.Start) return;
 
             var staged = subdevice.StagedRunConfig;
+            // Belt-and-suspenders: never fire a run whose mode the device can't honor (a volume run
+            // on a flow-less valve has no liters to count and would run indefinitely).
+            if (!RunModeRegistry.IsApplicable(subdevice.Model, subdevice.HasFlowMeter, staged.Mode))
+            {
+                _logger.LogWarning("Ignoring start for subdevice {Id}: staged mode {Mode} not applicable to {Model}", message.Id, staged.Mode, subdevice.Model);
+                return;
+            }
             var stagedValue = staged.Mode == RunModeKey.Volume ? staged.VolumeLiters : staged.DurationMinutes;
             if (stagedValue <= 0)
             {

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
@@ -94,11 +94,21 @@ namespace Ecowitt.Controller.Service.Orchestrator
             if (message.Mode.HasValue) subdevice.StagedRunConfig.Mode = message.Mode.Value;
             if (message.Duration.HasValue) subdevice.StagedRunConfig.DurationMinutes = message.Duration.Value;
             if (message.Volume.HasValue) subdevice.StagedRunConfig.VolumeLiters = message.Volume.Value;
-            _deviceStore.UpsertGateway(gw);
+            if (!_deviceStore.UpsertGateway(gw))
+            {
+                _logger.LogWarning("failed to update gateway {GwIp} in the store after staged run config merge", gw.IpAddress);
+            }
 
             if (!message.Start) return;
 
             var staged = subdevice.StagedRunConfig;
+            var stagedValue = staged.Mode == RunModeKey.Volume ? staged.VolumeLiters : staged.DurationMinutes;
+            if (stagedValue <= 0)
+            {
+                _logger.LogWarning("Ignoring start for subdevice {Id}: {Mode} value is {Value} (must be > 0)", message.Id, staged.Mode, stagedValue);
+                return;
+            }
+
             var cmd = staged.Mode == RunModeKey.Volume
                 ? new SubdeviceApiCommand { Cmd = Command.Start, Id = message.Id, Duration = staged.VolumeLiters, Unit = DurationUnit.Liters }
                 : new SubdeviceApiCommand { Cmd = Command.Start, Id = message.Id, Duration = staged.DurationMinutes, Unit = DurationUnit.Minutes };

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
@@ -35,11 +35,7 @@ namespace Ecowitt.Controller.Service.Orchestrator
                 return;
             }
 
-            // HA sends bare ON/OFF without duration — default to always-on
-            if (message.Cmd == Command.Start && !message.Duration.HasValue)
-            {
-                message.AlwaysOn = true;
-            }
+            GuardRunCommand(message);
 
             await _messageBus.Publish(new SubdeviceCommandDispatch
             {
@@ -48,6 +44,40 @@ namespace Ecowitt.Controller.Service.Orchestrator
                 Model = subdevice.Model
             });
         }
+
+        // Clamp/default a parameterized run command in place. Scoped to runs that carry a Unit;
+        // a bare Start (no Unit) is left on the existing always-on path. Clamping here (user units,
+        // before the adapter's multiply) makes downstream overflow impossible.
+        internal static void GuardRunCommand(SubdeviceApiCommand message)
+        {
+            if (message.Cmd != Command.Start) return;
+
+            if (message.Unit.HasValue)
+            {
+                var (_, max, def) = BoundsFor(message.Unit.Value);
+                var v = message.Duration ?? 0;
+                message.Duration = v <= 0 ? def : Math.Min(v, max);
+            }
+            else if (!message.Duration.HasValue)
+            {
+                message.AlwaysOn = true; // existing always-on behavior (HA switch ON)
+            }
+        }
+
+        // Bounds/default in the command's own unit. Time units share the same physical cap
+        // (1440 min = 24 h = 86400 s); volume uses the Volume mode bounds.
+        private static (int min, int max, int def) BoundsFor(DurationUnit unit) => unit switch
+        {
+            DurationUnit.Seconds => (1, 86400, 180),
+            DurationUnit.Minutes => (RunModeRegistry.ByKey(RunModeKey.Duration).Min,
+                                     RunModeRegistry.ByKey(RunModeKey.Duration).Max,
+                                     RunModeRegistry.ByKey(RunModeKey.Duration).Default),
+            DurationUnit.Hours   => (1, 24, 1),
+            DurationUnit.Liters  => (RunModeRegistry.ByKey(RunModeKey.Volume).Min,
+                                     RunModeRegistry.ByKey(RunModeKey.Volume).Max,
+                                     RunModeRegistry.ByKey(RunModeKey.Volume).Default),
+            _ => (1, 86400, 180)
+        };
 
         public async Task OnHandle(GatewayApiData message, CancellationToken cancellationToken)
         {

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.ConsumerHttp.cs
@@ -79,8 +79,40 @@ namespace Ecowitt.Controller.Service.Orchestrator
             _ => (1, 86400, 180)
         };
 
-        public Task OnHandle(SubdeviceRunConfig message, CancellationToken cancellationToken)
-            => Task.CompletedTask;
+        public async Task OnHandle(SubdeviceRunConfig message, CancellationToken cancellationToken)
+        {
+            var gw = _deviceStore.GetGatewayBySubdeviceId(message.Id);
+            var subdevice = gw?.Subdevices.FirstOrDefault(sd => sd.Id == message.Id);
+            if (gw == null || subdevice == null)
+            {
+                _logger.LogWarning("SubdeviceRunConfig for unknown subdevice {Id}", message.Id);
+                return;
+            }
+
+            // Merge non-null partials into the staged config. The subdevice is held by reference
+            // in the store, so the mutation is visible; UpsertGateway re-stores defensively.
+            if (message.Mode.HasValue) subdevice.StagedRunConfig.Mode = message.Mode.Value;
+            if (message.Duration.HasValue) subdevice.StagedRunConfig.DurationMinutes = message.Duration.Value;
+            if (message.Volume.HasValue) subdevice.StagedRunConfig.VolumeLiters = message.Volume.Value;
+            _deviceStore.UpsertGateway(gw);
+
+            if (!message.Start) return;
+
+            var staged = subdevice.StagedRunConfig;
+            var cmd = staged.Mode == RunModeKey.Volume
+                ? new SubdeviceApiCommand { Cmd = Command.Start, Id = message.Id, Duration = staged.VolumeLiters, Unit = DurationUnit.Liters }
+                : new SubdeviceApiCommand { Cmd = Command.Start, Id = message.Id, Duration = staged.DurationMinutes, Unit = DurationUnit.Minutes };
+
+            GuardRunCommand(cmd); // same guard as the direct path
+            _logger.LogInformation("Starting {Mode} run for subdevice {Id}", staged.Mode, message.Id);
+
+            await _messageBus.Publish(new SubdeviceCommandDispatch
+            {
+                GatewayIp = gw.IpAddress,
+                Command = cmd,
+                Model = subdevice.Model
+            });
+        }
 
         public async Task OnHandle(GatewayApiData message, CancellationToken cancellationToken)
         {

--- a/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.cs
+++ b/src/Ecowitt.Controller/Service/Orchestrator/Dispatcher.cs
@@ -10,7 +10,7 @@ using SlimMessageBus;
 
 namespace Ecowitt.Controller.Service.Orchestrator;
 
-public partial class Dispatcher : BackgroundService, IConsumer<MqttServiceEvent>, IConsumer<MqttConnectionEvent>, IConsumer<HomeAssistantStatusEvent>, IConsumer<SubdeviceApiCommand>, IConsumer<GatewayApiData>, IConsumer<GatewayLiveData>, IConsumer<SubdeviceApiAggregate>
+public partial class Dispatcher : BackgroundService, IConsumer<MqttServiceEvent>, IConsumer<MqttConnectionEvent>, IConsumer<HomeAssistantStatusEvent>, IConsumer<SubdeviceApiCommand>, IConsumer<SubdeviceRunConfig>, IConsumer<GatewayApiData>, IConsumer<GatewayLiveData>, IConsumer<SubdeviceApiAggregate>
 {
     private readonly ILogger<Dispatcher> _logger;
     private readonly IDeviceStore _deviceStore;


### PR DESCRIPTION
## Summary
Exposes the Ecowitt subdevice "run for a duration / volume" capability as first-class Home Assistant entities, so users trigger device-self-closing runs instead of orchestrating open → HA-timer → close. The command path already existed (`SubdeviceApiCommand` carries `Duration`/`Unit`) but was never exposed to HA or tested on hardware; this builds the control surface and verifies the encoding against real devices.

**Safety motivation:** with HA timers, a lost close command leaves a valve stuck open (flooding). With device-side duration, the single start command carries its own deadline — the worst case flips from "stuck open" to "didn't start."

## Entities (capability-driven, per controllable subdevice)
On top of the existing always-on switch (unchanged):
- **Run Mode** `select` — only when 2+ modes apply
- **Run Duration (min)** / **Run Volume (L)** `number`s — `entity_category: config`
- **Start Run** `button`

Capability resolver: **Duration** for all controllable subdevices (WFC01/WFC02/AC1100); **Volume** for WFC01 (flow built in) and WFC02 only when `flowmeter == 1`; never for AC1100. Single-mode devices skip the select.

## Architecture
- Staged config lives on the `Subdevice` in `DeviceStore`. A new `SubdeviceRunConfig` bus message carries partial updates + a Start flag; `MqttService` stays a pure translator (`+/subdevices/+/cmd/#` subscription routes the new topics); `Dispatcher` merges and, on Start, routes an assembled `SubdeviceApiCommand` through a shared `GuardRunCommand` into the existing `SubdeviceCommandDispatch` path.
- Magic numbers isolated in the gateway adapter (`SendSubdeviceCommand.ToGatewayRun`): time → seconds `val_type:0` (×60/×3600); volume → deciliters `val_type:3` (×10). **Verified on hardware** (a 5 L command reads back `val:50`).
- Guard scoped to parameterized runs (`Unit.HasValue`): a bare always-on Start (the HA switch) is left untouched; `null`/`≤0`/negative → default; over-max → clamp. Clamping before the multiply makes overflow impossible.

## Bug fixes folded in
- Case-insensitive direct-command deserialization (`PropertyNameCaseInsensitive` + `JsonStringEnumConverter`) so the documented lowercase payload actually binds; `docs/mqtt.md` corrected.

## Smoke tested — all green
- **WFC02** (dev): duration + volume runs self-close; switch preserved; direct-MQTT `-1` defaults to 3 min.
- **AC1100** (prod): duration-only entities, timed run self-closes.
- **WFC01** (prod): select + both numbers, duration and volume self-close.

The shared-protocol assumption for AC1100/WFC01 held — all three encode runs identically.

## Known limitation (documented, v1)
Staged config may reset to defaults after a *controller* restart (retained replay arrives before the subdevice is re-polled into the store). Device-side runs are unaffected; the user re-sets the number. Proper fix is a follow-up.

## Tests
210/210 (33 new across conversion, registry, capability resolver, flowmeter, discovery builders, guard, path-builder). Build clean.

## Out of scope
Cycle mode (registry-extensible), live state reflection, per-subdevice configurable defaults.